### PR TITLE
ci: auto-trigger blog data build after predictions

### DIFF
--- a/.github/workflows/daily-ratings-predictions.yml
+++ b/.github/workflows/daily-ratings-predictions.yml
@@ -157,6 +157,14 @@ jobs:
           echo "**Prediction Week:** ${{ steps.pred_info.outputs.afl_week }}" >> $GITHUB_STEP_SUMMARY
           echo "**Trigger:** ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
 
+      - name: Dispatch blog data build to torpdata
+        if: success()
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.WORKFLOW_PAT }}
+          repository: peteowen1/torpdata
+          event-type: blog-trigger
+
       - name: Notify on failure
         if: failure()
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary
- Dispatches `blog-trigger` event to torpdata after predictions complete
- Creates full automated daily chain: torpdata daily → torp ratings → torpdata blog/R2

## Test plan
- [ ] Run ratings pipeline manually and verify torpdata build-blog-data triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)