### PR TITLE
feat: team_ratings sum-of-top-21 with subcategory breakdowns

### DIFF
--- a/R/load_data.R
+++ b/R/load_data.R
@@ -523,8 +523,8 @@ load_player_season_ratings <- function(seasons = get_afl_season(), use_disk_cach
 #'
 #' @description Loads pre-computed team-level TORP aggregates from the
 #'   [torpdata repository](https://github.com/peteowen1/torpdata).
-#'   This data summarises per-round team ratings derived from individual
-#'   player TORP ratings.
+#'   Aggregates are the sum of TORP ratings for each team's top-21 players
+#'   (filtered to TORP > 0) per round, with subcategory breakdowns.
 #'
 #' @param columns Optional character vector of column names to read. If NULL (default), reads all columns.
 #'

--- a/R/local_data.R
+++ b/R/local_data.R
@@ -205,7 +205,9 @@ save_locally <- function(df, file_name) {
   }, error = function(e) {
     cli::cli_warn("Failed to save locally: {conditionMessage(e)}")
     # Remove stale local file so load functions don't serve outdated data
-    tryCatch(unlink(path), error = function(e2) NULL)
+    if (unlink(path) != 0L) {
+      cli::cli_warn("Could not remove stale local file: {.path {basename(path)}}")
+    }
     invisible(FALSE)
   })
 }

--- a/data-raw/01-data/daily_release.R
+++ b/data-raw/01-data/daily_release.R
@@ -631,8 +631,9 @@ run_daily_release <- function(force = FALSE) {
   # -------------------------------------------------------------------------
   tictoc::toc(log = TRUE)
 
-  if (length(derived_failures) > 0) {
-    cli::cli_alert_warning("Daily release complete with {length(derived_failures)} derived data failure{?s}: {paste(derived_failures, collapse = ', ')}")
+  all_failures <- c(seasonal_failures, derived_failures)
+  if (length(all_failures) > 0) {
+    cli::cli_alert_warning("Daily release complete with {length(all_failures)} failure{?s}: {paste(all_failures, collapse = ', ')}")
   } else {
     cli::cli_alert_success("Daily release complete!")
   }

--- a/data-raw/03-ratings/run_ratings_pipeline.R
+++ b/data-raw/03-ratings/run_ratings_pipeline.R
@@ -257,7 +257,7 @@ tryCatch({
   team_ratings <- ratings_for_teams |>
     dplyr::filter(.data$torp > 0) |>
     dplyr::group_by(.data$season, .data$round, .data$team) |>
-    dplyr::mutate(tm_rnk = rank(-.data$torp)) |>
+    dplyr::mutate(tm_rnk = rank(-.data$torp, ties.method = "first")) |>
     dplyr::filter(.data$tm_rnk <= 21) |>
     dplyr::summarise(
       team_torp    = round(sum(.data$torp, na.rm = TRUE), 2),

--- a/man/load_team_ratings.Rd
+++ b/man/load_team_ratings.Rd
@@ -17,8 +17,8 @@ A data frame containing team-level ratings with columns including
 \description{
 Loads pre-computed team-level TORP aggregates from the
 \href{https://github.com/peteowen1/torpdata}{torpdata repository}.
-This data summarises per-round team ratings derived from individual
-player TORP ratings.
+Aggregates are the sum of TORP ratings for each team's top-21 players
+(filtered to TORP > 0) per round, with subcategory breakdowns.
 }
 \examples{
 \donttest{


### PR DESCRIPTION
## Summary
- **team_ratings** now uses sum of top-21 players (filtered to `torp > 0`) instead of mean across all players, aligning with the predictions pipeline format
- Replaces `team_attack`/`team_defence` with individual subcategory columns: `team_recv`, `team_disp`, `team_spoil`, `team_hitout`
- Fixes stale local cache bug: when `save_locally()` fails to overwrite a file (e.g., file lock), the old copy is now deleted so `load_*()` functions fetch fresh data from GitHub

## Test plan
- [x] Ran ratings pipeline Stage 4 locally — `team_torp` values in ~65-131 sum range (previously ~2-4 mean range)
- [x] Verified `load_team_ratings()` returns new columns from GitHub release
- [ ] Full pipeline run via workflow dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)