### PR TITLE
Train match GAMs inline in daily pipeline

### DIFF
--- a/data-raw/02-models/build_match_predictions.R
+++ b/data-raw/02-models/build_match_predictions.R
@@ -561,6 +561,9 @@ run_predictions_pipeline <- function(week = NULL, weeks = NULL, season = NULL) {
   gam_df <- team_mdl_df |> filter(!is.na(win))
   train_mask <- !is.na(team_mdl_df$win)
   cli::cli_inform("Training on {nrow(gam_df)} completed matches")
+  if (nrow(gam_df) == 0) {
+    cli::cli_abort("Cannot train GAM models: 0 completed matches after filtering to season >= {MIN_DATA_SEASON} R{MIN_DATA_ROUND}")
+  }
 
   # Sequential GAM pipeline: each model's predictions feed into the next
   cli::cli_progress_step("Training total xPoints model")


### PR DESCRIPTION
## Summary
- Replaces pre-trained GAM loading from torpmodels with inline training on all completed matches
- Models retrain every daily run (~30s), so predictions always reflect the latest results
- Removes `load_model_with_fallback("match_gams")` dependency from the predictions pipeline

## Test plan
- [ ] Run `run_predictions_pipeline()` locally and verify predictions generate successfully
- [ ] Confirm GAM training completes in ~30s with cli progress output
- [ ] Compare predictions against previous torpmodels-based output for sanity check

🤖 Generated with [Claude Code](https://claude.com/claude-code)