### PR TITLE
feat: get_xg(), improved ratings API, fix shot model player mapping

### DIFF
--- a/R/add_variables.R
+++ b/R/add_variables.R
@@ -296,7 +296,7 @@ load_model_with_fallback <- function(model_name) {
     return(get(model_name, envir = .torp_model_cache))
   }
 
-  valid_models <- c("ep", "wp", "shot", "xgb_win", "match_gams")
+  valid_models <- c("ep", "wp", "shot", "xgb_win", "match_gams", "shot_player_df")
   if (!model_name %in% valid_models) {
     cli::cli_abort("Unknown model name: {model_name}. Must be one of: {paste(valid_models, collapse = ', ')}")
   }

--- a/R/analyze_match.R
+++ b/R/analyze_match.R
@@ -1,0 +1,274 @@
+#' Get Player Match Ratings
+#'
+#' Scrapes chain data for a match (or full round) and produces per-player
+#' EPV credit and game-level PSR ratings. Designed to be run immediately
+#' after a game finishes, using live API data rather than stored releases.
+#'
+#' @param match Input: either a match ID string (e.g. `"CD_M20260140201"`)
+#'   or a pre-scraped chains data.frame from [get_match_chains()].
+#'   If `NULL` (default), uses `season` and `round` to fetch chains.
+#' @param season Numeric season year (default: current season via
+#'   [get_afl_season()]). Only used when `match` is `NULL`.
+#' @param round Numeric round number. Only used when `match` is `NULL`.
+#'
+#' @return A data.table with one row per player per match, containing:
+#'   identifiers (player_id, match_id, player_name, team, opponent, position),
+#'   EPV components (epv, recv_epv, disp_epv, spoil_epv, hitout_epv, epv_adj),
+#'   game PSR (game_psr, game_osr, game_dsr), and key box-score stats.
+#'
+#' @export
+#'
+#' @examples
+#' \dontrun{
+#' # From match ID (scrapes everything automatically)
+#' result <- get_player_match_ratings("CD_M20260140201")
+#'
+#' # From season and round (all matches in the round)
+#' result <- get_player_match_ratings(round = 2)
+#' result <- get_player_match_ratings(season = 2025, round = 14)
+#'
+#' # From pre-scraped chains
+#' chains <- get_match_chains(2026, 2)
+#' result <- get_player_match_ratings(chains)
+#' }
+get_player_match_ratings <- function(match = NULL,
+                                     season = get_afl_season(),
+                                     round = NULL) {
+  # --- Resolve input: match ID, season+round, or pre-scraped chains ---
+  if (is.null(match)) {
+    if (is.null(round)) {
+      cli::cli_abort("Must provide either {.arg match} or {.arg round}.")
+    }
+    cli::cli_inform("Fetching chains for {.val {season}} round {.val {round}}...")
+    chains <- data.table::as.data.table(get_match_chains(season, round))
+    match_ids <- unique(chains$match_id)
+  } else if (is.character(match) && length(match) == 1 && grepl("^CD_M", match)) {
+    match_ids <- match
+    chains <- get_match_chains(match)
+  } else if (is.data.frame(match) && nrow(match) > 0) {
+    chains <- data.table::as.data.table(match)
+    match_ids <- unique(chains$match_id)
+  } else {
+    cli::cli_abort("{.arg match} must be a match ID string, a chains data.frame, or {.code NULL} (with {.arg round} specified).")
+  }
+
+  # --- Step 1: Run EPV pipeline ---
+  cli::cli_inform("Running EPV pipeline...")
+  pbp <- chains |>
+    clean_pbp() |>
+    clean_model_data_epv() |>
+    clean_shots_data() |>
+    add_shot_vars() |>
+    add_epv_vars() |>
+    clean_model_data_wp() |>
+    add_wp_vars()
+
+  # --- Step 2: Fetch player stats and lineups from API ---
+  cli::cli_inform("Fetching player stats and lineups from API...")
+  season <- as.numeric(substr(match_ids[1], 5, 8))
+
+  player_stats <- .fetch_match_player_stats(match_ids)
+  teams <- .fetch_match_lineups(match_ids, season)
+
+  # Add utc_start_time to player_stats (needed by create_player_game_data for
+  # decay weighting). Extract from chains metadata since API stats don't include it.
+  if (!"utc_start_time" %in% names(player_stats) && "utc_start_time" %in% names(chains)) {
+    start_times <- unique(chains[, .(match_id, utc_start_time)])
+    player_stats <- merge(player_stats, start_times, by = "match_id", all.x = TRUE)
+  }
+
+  # --- Step 3: Player-game EPV credit ---
+  cli::cli_inform("Computing player EPV credit...")
+  player_epv <- create_player_game_data(
+    pbp_data = pbp,
+    player_stats = player_stats,
+    teams = teams
+  )
+
+  # Skip position adjustment for single-game analysis (too few players per
+  # position group for a meaningful baseline). Use raw EPV instead.
+  player_epv <- data.table::as.data.table(player_epv)
+  player_epv[, `:=`(
+    epv_adj = epv,
+    recv_epv_adj = recv_epv,
+    disp_epv_adj = disp_epv,
+    spoil_epv_adj = spoil_epv,
+    hitout_epv_adj = hitout_epv
+  )]
+
+  # --- Step 4: Game PSR from raw stats ---
+  cli::cli_inform("Computing game PSR...")
+  player_epv <- .add_game_psr(player_epv)
+
+  cli::cli_inform("Done!")
+  player_epv[]
+}
+
+
+#' Fetch player stats for specific match IDs
+#'
+#' @param match_ids Character vector of match IDs.
+#' @return A data.frame of player stats with normalised column names.
+#' @keywords internal
+.fetch_match_player_stats <- function(match_ids) {
+  token <- get_token()
+  result <- .fetch_cfs_batch(
+    ids = match_ids,
+    url_template = "https://api.afl.com.au/cfs/afl/playerStats/match/%s",
+    token = token,
+    parse_fn = .parse_match_stats,
+    label = "player stats"
+  )
+  if (nrow(result) == 0) {
+    cli::cli_abort("No player stats returned for match{?es} {.val {match_ids}}.")
+  }
+
+  # Rename providerId -> match_id
+  if ("providerId" %in% names(result)) {
+    names(result)[names(result) == "providerId"] <- "match_id"
+  }
+
+  # Normalise column names to snake_case
+  result <- data.table::as.data.table(result)
+  .normalise_player_stats_columns(result)
+  result
+}
+
+
+#' Fetch team lineups for specific match IDs
+#'
+#' @param match_ids Character vector of match IDs.
+#' @param season Numeric season year.
+#' @return A data.frame of team lineup data with normalised column names.
+#' @keywords internal
+.fetch_match_lineups <- function(match_ids, season) {
+  token <- get_token()
+  result <- .fetch_cfs_batch(
+    ids = match_ids,
+    url_template = "https://api.afl.com.au/cfs/afl/matchRoster/full/%s",
+    token = token,
+    parse_fn = .parse_match_roster,
+    label = "lineups"
+  )
+  if (nrow(result) == 0) {
+    cli::cli_abort("No lineup data returned for match{?es} {.val {match_ids}}.")
+  }
+
+  result$season <- season
+
+  # Normalise column names
+  result <- .normalise_teams_columns(result)
+  result
+}
+
+
+#' Apply PSR coefficients to raw per-game stats
+#'
+#' Computes a game-level PSR by applying the glmnet coefficients directly
+#' to each player's box-score stats from a single game. Rate stats
+#' (efficiency percentages) are computed from the raw counts.
+#'
+#' @param player_epv A data.table from [create_player_game_data()].
+#' @return The input data.table with `game_psr`, `game_osr`, `game_dsr` added.
+#' @keywords internal
+.add_game_psr <- function(player_epv) {
+  dt <- data.table::as.data.table(player_epv)
+
+  # Load coefficient files
+  psr_coefs <- .load_psr_coefs("psr_v2_coefficients.csv")
+  osr_coefs <- .load_psr_coefs("osr_v2_coefficients.csv")
+  dsr_coefs <- .load_psr_coefs("dsr_v2_coefficients.csv")
+
+  if (is.null(psr_coefs)) {
+    cli::cli_warn("PSR coefficient file not found -- skipping game PSR")
+    dt[, c("game_psr", "game_osr", "game_dsr") := NA_real_]
+    return(dt)
+  }
+
+  # Ensure efficiency columns exist (may be missing from some API responses)
+  for (col in c("effective_disposals", "effective_kicks")) {
+    if (!col %in% names(dt)) dt[, (col) := 0L]
+  }
+
+  # Compute rate stats from raw counts
+  dt[, `:=`(
+    disposal_efficiency = data.table::fifelse(disposals > 0, effective_disposals / disposals, 0),
+    goal_accuracy = data.table::fifelse(shots_at_goal > 0, goals / shots_at_goal, 0),
+    kick_efficiency = data.table::fifelse(kicks > 0, effective_kicks / kicks, 0),
+    contested_poss_rate = data.table::fifelse(
+      (contested_possessions + uncontested_possessions) > 0,
+      contested_possessions / (contested_possessions + uncontested_possessions),
+      0
+    ),
+    hitout_win_pct = data.table::fifelse(
+      hitouts > 0,
+      hitouts_to_advantage / hitouts,
+      0
+    )
+  )]
+
+  # Apply coefficients
+  dt[, game_psr := .apply_coefs(dt, psr_coefs)]
+  if (!is.null(osr_coefs) && !is.null(dsr_coefs)) {
+    raw_osr <- .apply_coefs(dt, osr_coefs)
+    raw_dsr <- .apply_coefs(dt, dsr_coefs)
+    # Reconcile so osr + dsr = psr
+    delta <- (dt$game_psr - raw_osr - raw_dsr) / 2
+    dt[, game_osr := raw_osr + delta]
+    dt[, game_dsr := raw_dsr + delta]
+  } else {
+    dt[, c("game_osr", "game_dsr") := NA_real_]
+  }
+
+  # Clean up temporary rate columns
+  dt[, c("disposal_efficiency", "goal_accuracy", "kick_efficiency",
+         "contested_poss_rate", "hitout_win_pct") := NULL]
+
+  dt
+}
+
+
+#' Apply PSR coefficients to a data.table of player stats
+#'
+#' @param dt A data.table with stat columns.
+#' @param coefs A data.frame with stat_name, beta, sd columns.
+#' @return A numeric vector of PSR values (one per row).
+#' @keywords internal
+.apply_coefs <- function(dt, coefs) {
+  # Filter to stats that exist in the data
+  available <- coefs$stat_name %in% names(dt)
+  if (sum(available) == 0) return(rep(0, nrow(dt)))
+
+  coefs <- coefs[available, , drop = FALSE]
+  stat_cols <- coefs$stat_name
+  betas <- coefs$beta
+  sds <- coefs$sd
+  sds[sds == 0 | is.na(sds)] <- 1
+
+  mat <- as.matrix(dt[, stat_cols, with = FALSE])
+  mat[is.na(mat)] <- 0
+
+  # Standardise then apply betas
+  mat <- sweep(mat, 2, sds, "/")
+  as.numeric(mat %*% betas)
+}
+
+
+#' Load PSR coefficient CSV
+#'
+#' @param filename The coefficient CSV filename.
+#' @return A data.frame with stat_name, beta, sd columns, or NULL if not found.
+#' @keywords internal
+.load_psr_coefs <- function(filename) {
+  path <- system.file("extdata", filename, package = "torp")
+  if (path == "") {
+    fallback <- file.path(
+      find.package("torp", quiet = TRUE)[1] %||% ".",
+      "data-raw", "cache-skills", filename
+    )
+    if (file.exists(fallback)) path <- fallback
+  }
+  if (path == "" || !file.exists(path)) return(NULL)
+  coefs <- utils::read.csv(path)
+  coefs[coefs$beta != 0, , drop = FALSE]
+}

--- a/R/clean_features.R
+++ b/R/clean_features.R
@@ -424,15 +424,13 @@ select_afl_xgb_vars <- function(df) {
 #' @param df A dataframe containing raw shot data.
 #' @return A cleaned dataframe with additional shot-related variables.
 #' @keywords internal
-#' @importFrom utils data
 clean_shots_data <- function(df) {
   goal_width <- AFL_GOAL_WIDTH
   
-  # Load shot player data safely
-  shot_player_df <- NULL
-  tryCatch(
-    utils::data("shot_player_df", package = "torp", envir = environment()),
-    warning = function(w) NULL
+  # Load shot player lookup (maps player_id to lumped factor for shot model)
+  shot_player_df <- tryCatch(
+    load_model_with_fallback("shot_player_df"),
+    error = function(e) NULL
   )
 
   df <- df |>

--- a/R/load_data.R
+++ b/R/load_data.R
@@ -398,6 +398,7 @@ load_pbp <- function(seasons = get_afl_season(), rounds = TRUE, use_disk_cache =
 #' @description Loads xg data from the [torpdata repository](https://github.com/peteowen1/torpdata)
 #'
 #' @param seasons A numeric vector of 4-digit years associated with given AFL seasons - defaults to latest season. If set to `TRUE`, returns all available data since 2021.
+#' @param rounds A numeric vector of round numbers to filter to. If `NULL` (default), returns all rounds.
 #' @param use_disk_cache Logical. If TRUE, uses persistent disk cache for faster repeated loads. Default is FALSE.
 #' @param columns Optional character vector of column names to read. If NULL (default), reads all columns.
 #'
@@ -407,10 +408,11 @@ load_pbp <- function(seasons = get_afl_season(), rounds = TRUE, use_disk_cache =
 #' \dontrun{
 #' try({ # prevents cran errors
 #'   load_xg(2021:2022)
+#'   load_xg(2026, 2)
 #' })
 #' }
 #' @export
-load_xg <- function(seasons = get_afl_season(), use_disk_cache = FALSE, columns = NULL) {
+load_xg <- function(seasons = get_afl_season(), rounds = NULL, use_disk_cache = FALSE, columns = NULL) {
   seasons <- validate_seasons(seasons)
 
   urls <- generate_urls("xg-data", "xg_data", seasons)
@@ -420,6 +422,13 @@ load_xg <- function(seasons = get_afl_season(), use_disk_cache = FALSE, columns 
   # Normalise old column names (home_sG → home_scored_goals, etc.)
   if (nrow(out) > 0) {
     .normalise_columns(out, XG_COL_MAP)
+  }
+
+  # Filter by round if requested (round parsed from match_id chars 12-13)
+  if (!is.null(rounds) && nrow(out) > 0) {
+    if (!data.table::is.data.table(out)) out <- data.table::as.data.table(out)
+    out[, round_number := as.integer(substr(match_id, 12L, 13L))]
+    out <- out[round_number %in% as.integer(rounds)]
   }
 
   return(out)

--- a/R/xg.R
+++ b/R/xg.R
@@ -69,6 +69,122 @@ calculate_match_xgs <- function(season = get_afl_season(), round = get_afl_week(
   return(shots_df)
 }
 
+
+#' Get Live xG for a Match or Round
+#'
+#' Scrapes chain data from the AFL API, runs the shot model pipeline, and
+#' computes match-level xG summaries. Useful for matches that just finished
+#' before the daily torpdata pipeline has run.
+#'
+#' @param match Input: either a match ID string (e.g. `"CD_M20260140201"`)
+#'   or a pre-scraped chains data.frame from [get_match_chains()].
+#'   If `NULL` (default), uses `season` and `round` to fetch chains.
+#' @param season Numeric season year (default: current season via
+#'   [get_afl_season()]). Only used when `match` is `NULL`.
+#' @param round Numeric round number. Only used when `match` is `NULL`.
+#' @param quarter Numeric vector of quarters to include (default: `1:4`).
+#' @param detail Logical. If `TRUE`, returns the full play-by-play data
+#'   (filtered to shots) instead of match-level summaries. Useful for
+#'   debugging xG values. Default is `FALSE`.
+#'
+#' @return When `detail = FALSE` (default), a tibble with one row per match.
+#'   When `detail = TRUE`, the full shot-level PBP with columns like
+#'   `xscore`, `goal_prob`, `behind_prob`, `points_shot`, `shot_row`.
+#'
+#' @export
+#'
+#' @examples
+#' \dontrun{
+#' # From match ID
+#' get_xg("CD_M20260140201")
+#'
+#' # From season and round (all matches in the round)
+#' get_xg(round = 2)
+#' get_xg(season = 2025, round = 14)
+#'
+#' # Debug: return shot-level data
+#' get_xg(round = 2, detail = TRUE)
+#'
+#' # From pre-scraped chains
+#' chains <- get_match_chains(2026, 2)
+#' get_xg(chains)
+#' }
+get_xg <- function(match = NULL,
+                   season = get_afl_season(),
+                   round = NULL,
+                   quarter = 1:4,
+                   detail = FALSE) {
+  # --- Resolve input: match ID, season+round, or pre-scraped chains ---
+  if (is.null(match)) {
+    if (is.null(round)) {
+      cli::cli_abort("Must provide either {.arg match} or {.arg round}.")
+    }
+    cli::cli_inform("Fetching chains for {.val {season}} round {.val {round}}...")
+    chains <- get_match_chains(season, round)
+  } else if (is.character(match) && length(match) == 1 && grepl("^CD_M", match)) {
+    chains <- get_match_chains(match)
+  } else if (is.data.frame(match) && nrow(match) > 0) {
+    chains <- match
+  } else {
+    cli::cli_abort("{.arg match} must be a match ID string, a chains data.frame, or {.code NULL} (with {.arg round} specified).")
+  }
+
+  # --- Run shot model pipeline ---
+  cli::cli_inform("Running shot model pipeline...")
+  pbp <- chains |>
+    clean_pbp() |>
+    clean_model_data_epv() |>
+    clean_shots_data() |>
+    add_shot_vars()
+
+  # --- Detail mode: return shot-level rows for debugging ---
+  if (detail) {
+    cli::cli_inform("Done! Returning shot-level detail.")
+    return(pbp |> dplyr::filter(.data$shot_row == 1, .data$period %in% quarter))
+  }
+
+  # --- Summarise to match-level xG (reuse calculate_match_xgs logic) ---
+  pbp <- pbp |>
+    dplyr::mutate(
+      home_team_name = torp_replace_teams(.data$home_team_name),
+      away_team_name = torp_replace_teams(.data$away_team_name)
+    )
+
+  shots_df <- pbp |>
+    dplyr::group_by(.data$match_id) |>
+    dplyr::filter(.data$period %in% quarter) |>
+    dplyr::summarise(
+      home_team = max(.data$home_team_name),
+      home_shots_score = sum(dplyr::if_else(.data$team == .data$home_team_name, .data$points_shot, 0), na.rm = TRUE),
+      home_xscore = sum(dplyr::if_else(.data$team == .data$home_team_name, .data$xscore * .data$shot_row, 0), na.rm = TRUE),
+      home_scored_goals = sum(dplyr::if_else(.data$team == .data$home_team_name, dplyr::if_else(.data$points_shot == 6, 1, 0), 0), na.rm = TRUE),
+      home_scored_behinds = sum(dplyr::if_else(.data$team == .data$home_team_name, dplyr::if_else(.data$points_shot == 1, 1, 0), 0), na.rm = TRUE),
+      away_team = max(.data$away_team_name),
+      away_shots_score = sum(dplyr::if_else(.data$team == .data$away_team_name, .data$points_shot, 0), na.rm = TRUE),
+      away_xscore = sum(dplyr::if_else(.data$team == .data$away_team_name, .data$xscore * .data$shot_row, 0), na.rm = TRUE),
+      away_scored_goals = sum(dplyr::if_else(.data$team == .data$away_team_name, dplyr::if_else(.data$points_shot == 6, 1, 0), 0), na.rm = TRUE),
+      away_scored_behinds = sum(dplyr::if_else(.data$team == .data$away_team_name, dplyr::if_else(.data$points_shot == 1, 1, 0), 0), na.rm = TRUE),
+      score_diff = .data$home_shots_score - .data$away_shots_score,
+      xscore_diff = .data$home_xscore - .data$away_xscore,
+      total_points = .data$home_shots_score + .data$away_shots_score,
+      total_xpoints = .data$home_xscore + .data$away_xscore,
+      .groups = "drop"
+    )
+
+  zero_xg <- shots_df$match_id[shots_df$total_xpoints == 0]
+  if (length(zero_xg) > 0) {
+    cli::cli_warn(c(
+      "{length(zero_xg)} match{?es} ha{?s/ve} zero total xscore -- likely a team name mismatch.",
+      "i" = "Check that PBP 'team' col matches 'home_team_name'/'away_team_name'.",
+      "i" = "Affected: {paste(utils::head(zero_xg, 5), collapse = ', ')}"
+    ))
+  }
+
+  cli::cli_inform("Done!")
+  shots_df
+}
+
+
 #' @rdname calculate_match_xgs
 #' @description `match_xgs()` is deprecated; use `calculate_match_xgs()` instead.
 #' @export
@@ -76,3 +192,4 @@ match_xgs <- function(season = get_afl_season(), round = get_afl_week(), quarter
   .Deprecated("calculate_match_xgs", package = "torp", old = "match_xgs")
   calculate_match_xgs(season = season, round = round, quarter = quarter)
 }
+

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -102,6 +102,8 @@ reference:
   - title: Match Analysis
     desc: Match-level expected goals, predictions, and head-to-head comparisons
     contents:
+      - get_player_match_ratings
+      - get_xg
       - calculate_match_xgs
       - head_to_head
       - print.torp_head_to_head


### PR DESCRIPTION
## Summary
- **New `get_xg()` function**: live xG from AFL API — accepts match ID, season+round, or pre-scraped chains. Includes `detail=TRUE` for shot-level debugging
- **Improved `get_player_match_ratings()`**: now accepts `season`/`round` args alongside existing match ID input (e.g. `get_player_match_ratings(round = 2)`)
- **`load_xg()` round filtering**: new `rounds` parameter (e.g. `load_xg(2026, 2)`)
- **Fixed shot model player mapping**: `clean_shots_data()` was loading `shot_player_df` via `utils::data()` from `torp/data/` which didn't exist — now loads via `load_model_with_fallback()` from torpmodels. 637 known shooters get proper factor levels for the shot GAM random effect instead of all being "Other"

**Depends on:** peteowen1/torpmodels#6 (must merge first)

## Test plan
- [ ] `get_xg(round = 2)` returns correct match-level xG for all round 2 matches
- [ ] `get_xg(round = 2, detail = TRUE)` returns shot-level rows with real `player_id_shot` values (not all "Other")
- [ ] `get_xg("CD_M20260140201")` works for single match
- [ ] `get_player_match_ratings(round = 2)` returns player ratings for full round
- [ ] `load_xg(2026, 2)` filters to round 2 only
- [ ] `match_xgs()` still works (deprecated alias preserved for daily pipeline)
- [ ] After merging both PRs, rebuild historical PBP to fix stored xscore values

🤖 Generated with [Claude Code](https://claude.com/claude-code)