### PR TITLE
Fix broken ratings pipeline + PSR defensive guard

### DIFF
--- a/R/player_ratings.R
+++ b/R/player_ratings.R
@@ -493,6 +493,12 @@ calculate_torp <- function(epr_df, psr_df, epr_weight = TORP_EPR_WEIGHT) {
     dplyr::select(-dplyr::any_of(c("season", "round")))
 
   result <- dplyr::left_join(epr_df, latest_psr, by = "player_id")
+
+  # Ensure psr column exists even if join didn't add it
+  if (!"psr" %in% names(result)) {
+    cli::cli_warn("PSR column missing after join \u2014 defaulting all players to prior rate")
+    result$psr <- PSR_PRIOR_RATE
+  }
   result$psr[is.na(result$psr)] <- PSR_PRIOR_RATE
   if ("osr" %in% names(result)) result$osr[is.na(result$osr)] <- PSR_PRIOR_RATE / 2
   if ("dsr" %in% names(result)) result$dsr[is.na(result$dsr)] <- PSR_PRIOR_RATE / 2

--- a/data-raw/03-ratings/run_ratings_pipeline.R
+++ b/data-raw/03-ratings/run_ratings_pipeline.R
@@ -347,7 +347,7 @@ if (nrow(torp_new) > 0) {
     cli::cli_warn("Could not compute PSR for release: {e$message}")
     NULL
   })
-  if (!is.null(psr_df)) {
+  if (!is.null(psr_df) && nrow(psr_df) > 0 && "psr" %in% names(psr_df)) {
     torp_df_total <- calculate_torp(torp_df_total, psr_df)
     cli::cli_alert_success("Blended PSR into ratings ({sum(!is.na(torp_df_total$torp))} rows with torp)")
   }


### PR DESCRIPTION
## Summary
- **Fix PSR crash** — `calculate_torp()` crashes when `psr_df` lacks the `psr` column after `left_join`. Ratings, predictions, and blog data have been stale since March 18.
- **Defensive guard in pipeline** — `run_ratings_pipeline.R` now validates `nrow > 0` and `"psr" %in% names()` before calling `calculate_torp()`
- **Defensive guard in function** — `calculate_torp()` creates `psr` column with `PSR_PRIOR_RATE` default if join didn't add it, with a `cli_warn`

(Also includes accumulated dev changes: PSR model, EPR/EPV renames, injury pipeline, ladder improvements, xG functions, etc.)

## Test plan
- [ ] `devtools::check()` passes
- [ ] Manually trigger `daily-data-release.yml` after merge → verify ratings-trigger succeeds
- [ ] Verify ratings, predictions, and blog data update end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)