### PR TITLE
Fix calculate_torp() idempotency: strip stale PSR columns before join

### DIFF
--- a/R/player_ratings.R
+++ b/R/player_ratings.R
@@ -492,6 +492,14 @@ calculate_torp <- function(epr_df, psr_df, epr_weight = TORP_EPR_WEIGHT) {
     dplyr::ungroup() |>
     dplyr::select(-dplyr::any_of(c("season", "round")))
 
+  # Remove pre-existing psr/osr/dsr/torp columns (and any .x/.y suffixed
+  # duplicates from prior joins) to prevent column name collisions when
+  # epr_df was loaded from a previous pipeline run that already blended PSR
+  stale_cols <- grep("^(psr|osr|dsr|torp)(\\.|$)", names(epr_df), value = TRUE)
+  if (length(stale_cols) > 0) {
+    epr_df <- epr_df[, setdiff(names(epr_df), stale_cols), drop = FALSE]
+  }
+
   result <- dplyr::left_join(epr_df, latest_psr, by = "player_id")
 
   # Ensure psr column exists even if join didn't add it


### PR DESCRIPTION
## Summary
- Fix `calculate_torp()` column collision when `epr_df` already has `psr`/`osr`/`dsr`/`torp` columns from a previous pipeline run
- Without this fix, `left_join` creates `psr.x`/`psr.y` suffixes, the PSR check fails, and all players get `PSR_PRIOR_RATE = -2`
- Strip any pre-existing stale columns (including `.x`/`.y` duplicates) before the join

## Test plan
- [x] `Daily Ratings & Predictions` workflow succeeds on `dev`
- [x] Release parquet has single `psr` column with correct values (Bontempelli PSR=5.60, not -2.00)
- [x] Blog players page shows correct TORP/PSR/OSR/DSR

🤖 Generated with [Claude Code](https://claude.com/claude-code)