### PR TITLE
Fix pipeline: export missing helper functions from daily_release env

### DIFF
--- a/data-raw/03-ratings/run_epr_pipeline.R
+++ b/data-raw/03-ratings/run_epr_pipeline.R
@@ -29,6 +29,8 @@ devtools::load_all()
 source(here::here("data-raw/01-data/daily_release.R"), local = .daily_release_env)
 update_player_stats <- .daily_release_env$update_player_stats
 update_teams <- .daily_release_env$update_teams
+get_start_round <- .daily_release_env$get_start_round
+get_max_round <- .daily_release_env$get_max_round
 
 # Configuration ----
 # These defaults are only set if not already defined (allows CI to override)


### PR DESCRIPTION
## Summary
Stage 5 (player_game_ratings) was silently failing with "could not find function get_start_round" because the earlier env isolation of daily_release.R only exported 2 of 4 needed functions.

This caused player_game_ratings to never regenerate, which is why WPA columns weren't showing up in `player_game_ratings()` output.

## Test plan
- [ ] Pipeline re-run: Stage 5 should take >0.1s and release player_game_ratings with WPA columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)