### PR TITLE
fix: coalesce old rating columns in locked predictions

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -564,6 +564,8 @@ Old parquet files with legacy column names are normalised automatically at load 
 | 06 | `data-raw/06-stat-ratings/` | `04_export_stat_ratings.R` | Per-season parquet export to torpdata |
 | 06 | `data-raw/06-stat-ratings/` | `05_compare_psr_models.R` | Compare PSR model versions and coefficient stability |
 | 06 | `data-raw/06-stat-ratings/` | `06_train_psr_model.R` | glmnet PSR model: stat ratings -> score prediction |
+| -- | `scripts/` | `live-model-export.R` | Export xG lookup + EPV weights as JSON for inthegame-blog |
+| -- | `scripts/` | `ep-var-importance.R` | EP model variable importance analysis |
 
 ## Glossary
 

--- a/R/match_model.R
+++ b/R/match_model.R
@@ -524,11 +524,17 @@ run_predictions_pipeline <- function(week = NULL, weeks = NULL, season = NULL) {
       data.table::setnames(existing, "providerId", "match_id")
     }
 
-    # Backward compat: rename home_rating/away_rating/rating_diff -> home_epr/away_epr/epr_diff
+    # Backward compat: merge home_rating/away_rating/rating_diff -> home_epr/away_epr/epr_diff
     old_to_new <- c(home_rating = "home_epr", away_rating = "away_epr", rating_diff = "epr_diff")
     for (old_nm in names(old_to_new)) {
-      if (old_nm %in% names(existing) && !old_to_new[old_nm] %in% names(existing)) {
-        names(existing)[names(existing) == old_nm] <- old_to_new[old_nm]
+      new_nm <- old_to_new[old_nm]
+      if (old_nm %in% names(existing)) {
+        if (new_nm %in% names(existing)) {
+          existing[[new_nm]] <- dplyr::coalesce(existing[[new_nm]], existing[[old_nm]])
+          existing[[old_nm]] <- NULL
+        } else {
+          names(existing)[names(existing) == old_nm] <- new_nm
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- Fix dual-column bug where both `home_rating` (old) and `home_epr` (new) existed in locked predictions parquet/CSV
- Week 3 predictions were locked before the EPR rename, so the backward-compat code saw both columns and skipped the rename — leaving NAs in `home_epr` for 7 rows
- Now coalesces old → new columns when both exist, then drops the old ones
- Likely cause of Squiggle reporting "In The Game is offline"

## Test plan
- [ ] Verify predictions CSV has no duplicate columns after next pipeline run
- [ ] Confirm Squiggle stops reporting offline

🤖 Generated with [Claude Code](https://claude.com/claude-code)