### PR TITLE
Shot distance fix + WPA filter hardening (defensive only)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: torp
 Title: AFL Analytics and Player Rating System
-Version: 1.3.4
+Version: 1.3.5
 Authors@R: 
     person("Pete", "Owen", , "pete.owen1@hotmail.co.uk", role = c("aut", "cre"))
 Description: Provides tools for Australian Football League (AFL) analytics including 

--- a/R/clean_features.R
+++ b/R/clean_features.R
@@ -595,7 +595,7 @@ add_shot_result_variables <- function(df) {
 #'
 #' BAND-AID: when `venue_length` is in `names(df)`, `goal_x` is folded to the
 #' near-goal distance via `pmin(goal_x, venue_length - goal_x)` before the
-#' geometry calculation. This is NOT a coordinate-frame fix — it works around
+#' geometry calculation. This is NOT a coordinate-frame fix -- it works around
 #' an upstream issue where `clean_pbp::fix_chain_coordinates_dt` mis-flips
 #' a small fraction of shot_at_goal rows from positive to negative `x` (the
 #' iterative neighbour-based sign-flip cascades from a wrong anchor row when
@@ -618,7 +618,7 @@ add_shot_result_variables <- function(df) {
 #' @param df A dataframe containing shot data. Pass `venue_length` to enable
 #'   the near-goal fold (recommended for any production caller). Without it,
 #'   `goal_x` is used as-is, which assumes the caller has already mirrored
-#'   coordinates to be positive — only suitable for synthetic test fixtures.
+#'   coordinates to be positive -- only suitable for synthetic test fixtures.
 #' @param goal_width The width of the goal.
 #' @return A dataframe with additional shot geometry variables.
 #' @keywords internal
@@ -629,7 +629,7 @@ add_shot_geometry_variables <- function(df, goal_width) {
       dplyr::mutate(
         goal_x_near = pmin(.data$goal_x, .data$venue_length - .data$goal_x)
       )
-    # NA venue_length silently propagates through pmin → NaN angle → NA
+    # NA venue_length silently propagates through pmin -> NaN angle -> NA
     # distance, poisoning every downstream shot feature. Warn so the upstream
     # data defect is visible instead of swallowed. Predicate isolates the
     # venue_length defect specifically (not NA goal_x from other causes) so
@@ -638,7 +638,7 @@ add_shot_geometry_variables <- function(df, goal_width) {
     if (n_bad_venue > 0L) {
       cli::cli_warn(
         "{.fn add_shot_geometry_variables}: {n_bad_venue} row{?s} {?has/have} \\
-         NA {.code venue_length} — shot {.code distance} and {.code angle} \\
+         NA {.code venue_length} -- shot {.code distance} and {.code angle} \\
          will be NA. Check upstream data."
       )
     }

--- a/R/clean_features.R
+++ b/R/clean_features.R
@@ -590,17 +590,32 @@ add_shot_result_variables <- function(df) {
 
 #' Add Shot Geometry Variables
 #'
-#' Computes side_b, side_c, angle, and distance to the attacking goal.
-#' Internally folds `goal_x` to the near-goal distance: a player at x = -30
-#' on a 165m field has goal_x = halfLen - x = 112.5 (signed), but the actual
-#' distance to the goal they're attacking is 52.5m. Pre-fold, shots from
-#' negative-x reported distance to the FAR goal — visible on the blog as e.g.
-#' a 126m behind that should have been 40m. The fold uses venue_length when
-#' available; tests / legacy callers without venue_length fall through to
-#' the raw goal_x (which assumes coords are already pre-mirrored to be
-#' positive).
+#' Computes shot `angle` and `distance` to the attacking goal (plus
+#' intermediate trig legs `side_b` / `side_c`).
 #'
-#' @param df A dataframe containing shot data.
+#' BAND-AID: when `venue_length` is in `names(df)`, `goal_x` is folded to the
+#' near-goal distance via `pmin(goal_x, venue_length - goal_x)` before the
+#' geometry calculation. This is NOT a coordinate-frame fix — it works around
+#' an upstream issue where `clean_pbp::fix_chain_coordinates_dt` mis-flips
+#' ~7% of shot_at_goal rows from positive to negative `x` (the iterative
+#' neighbour-based sign-flip cascades from a wrong anchor row when there's
+#' API noise in the chain). Without the fold, those rows render as e.g. 126m
+#' behinds when the truth is ~40m. The fold only corrects user-facing
+#' `distance` / `angle`; the underlying `x` and `goal_x` columns remain
+#' wrong for those rows, which is fine because the EP/WP/shot models were
+#' trained on the same buggy `x` and are internally consistent with it.
+#' See `project_clean_pbp_sign_flip_cascade` in memory for the full
+#' investigation and the path to a proper upstream fix (model retraining
+#' required).
+#'
+#' Side effect: the rare ~0.2% of genuine long-range shots from own half
+#' (real `x < 0` cases per CLAUDE.md's team-relative coords) will also be
+#' folded to near-goal distance. Acceptable trade-off vs the 7% mis-flip.
+#'
+#' @param df A dataframe containing shot data. Pass `venue_length` to enable
+#'   the near-goal fold (recommended for any production caller). Without it,
+#'   `goal_x` is used as-is, which assumes the caller has already mirrored
+#'   coordinates to be positive — only suitable for synthetic test fixtures.
 #' @param goal_width The width of the goal.
 #' @return A dataframe with additional shot geometry variables.
 #' @keywords internal
@@ -611,6 +626,17 @@ add_shot_geometry_variables <- function(df, goal_width) {
       dplyr::mutate(
         goal_x_near = pmin(.data$goal_x, .data$venue_length - .data$goal_x)
       )
+    # NA venue_length silently propagates through pmin → NaN angle → NA
+    # distance, poisoning every downstream shot feature. Warn so the upstream
+    # data defect is visible instead of swallowed.
+    n_poisoned <- sum(is.na(df$goal_x_near) & !is.na(df$goal_x))
+    if (n_poisoned > 0L) {
+      cli::cli_warn(
+        "{.fn add_shot_geometry_variables}: {n_poisoned} row{?s} have NA \\
+         {.code venue_length} — shot {.code distance} and {.code angle} \\
+         will be NA. Check upstream data."
+      )
+    }
   } else {
     df <- df |>
       dplyr::mutate(goal_x_near = .data$goal_x)

--- a/R/clean_features.R
+++ b/R/clean_features.R
@@ -597,20 +597,23 @@ add_shot_result_variables <- function(df) {
 #' near-goal distance via `pmin(goal_x, venue_length - goal_x)` before the
 #' geometry calculation. This is NOT a coordinate-frame fix — it works around
 #' an upstream issue where `clean_pbp::fix_chain_coordinates_dt` mis-flips
-#' ~7% of shot_at_goal rows from positive to negative `x` (the iterative
-#' neighbour-based sign-flip cascades from a wrong anchor row when there's
-#' API noise in the chain). Without the fold, those rows render as e.g. 126m
-#' behinds when the truth is ~40m. The fold only corrects user-facing
-#' `distance` / `angle`; the underlying `x` and `goal_x` columns remain
-#' wrong for those rows, which is fine because the EP/WP/shot models were
-#' trained on the same buggy `x` and are internally consistent with it.
-#' See `project_clean_pbp_sign_flip_cascade` in memory for the full
-#' investigation and the path to a proper upstream fix (model retraining
-#' required).
+#' a small fraction of shot_at_goal rows from positive to negative `x` (the
+#' iterative neighbour-based sign-flip cascades from a wrong anchor row when
+#' there's API noise in the chain). On 2026 R1 chain data the mis-flip rate
+#' on shots was ~7% post-`clean_pbp` vs ~0.2% in raw chains. Without the
+#' fold, those rows render as e.g. 126m behinds when the truth is ~40m. The
+#' fold only corrects user-facing `distance` / `angle`; the underlying `x`
+#' and `goal_x` columns remain wrong for those rows, which is fine because
+#' the EP/WP/shot models were trained on the same buggy `x` and are
+#' internally consistent with it. The full investigation and path to a
+#' proper upstream fix (model retraining required) is tracked in the
+#' internal `project_clean_pbp_sign_flip_cascade` notes; root-cause file
+#' is `R/clean_pbp.R::fix_chain_coordinates_dt`.
 #'
-#' Side effect: the rare ~0.2% of genuine long-range shots from own half
-#' (real `x < 0` cases per CLAUDE.md's team-relative coords) will also be
-#' folded to near-goal distance. Acceptable trade-off vs the 7% mis-flip.
+#' Side effect: genuine long-range shots from own half (real `x < 0` cases
+#' per CLAUDE.md's team-relative coords; ~0.2% of shots in measured data)
+#' also get folded to near-goal distance. Acceptable trade-off vs the
+#' mis-flip case.
 #'
 #' @param df A dataframe containing shot data. Pass `venue_length` to enable
 #'   the near-goal fold (recommended for any production caller). Without it,
@@ -628,12 +631,14 @@ add_shot_geometry_variables <- function(df, goal_width) {
       )
     # NA venue_length silently propagates through pmin → NaN angle → NA
     # distance, poisoning every downstream shot feature. Warn so the upstream
-    # data defect is visible instead of swallowed.
-    n_poisoned <- sum(is.na(df$goal_x_near) & !is.na(df$goal_x))
-    if (n_poisoned > 0L) {
+    # data defect is visible instead of swallowed. Predicate isolates the
+    # venue_length defect specifically (not NA goal_x from other causes) so
+    # the warning message is provably accurate.
+    n_bad_venue <- sum(is.na(df$venue_length) & !is.na(df$goal_x))
+    if (n_bad_venue > 0L) {
       cli::cli_warn(
-        "{.fn add_shot_geometry_variables}: {n_poisoned} row{?s} have NA \\
-         {.code venue_length} — shot {.code distance} and {.code angle} \\
+        "{.fn add_shot_geometry_variables}: {n_bad_venue} row{?s} {?has/have} \\
+         NA {.code venue_length} — shot {.code distance} and {.code angle} \\
          will be NA. Check upstream data."
       )
     }

--- a/R/clean_pbp.R
+++ b/R/clean_pbp.R
@@ -131,10 +131,27 @@ add_team_id_mdl_dt <- function(dt) {
 #' jumps around throw-ins and ambiguous possession events, then converts back to
 #' possession-team perspective.
 #'
+#' Known limitation: the iterative neighbour-based sign-flip routine in
+#' steps C-F can cascade from a wrong anchor row when there's API noise
+#' (duplicate / oscillating chain rows), wrongly flipping a chain of
+#' correctly-positioned rows to match an outlier predecessor. Empirically
+#' affects ~7% of shot_at_goal rows. `R/clean_features.R::add_shot_geometry_variables`
+#' folds the resulting bad `goal_x` to a near-goal distance as a downstream
+#' band-aid for user-facing display, but the underlying `x` is still wrong
+#' for those rows (consumed by EP/WP/shot models). A proper fix needs
+#' rework of the correction algorithm AND retraining of the EP, WP, and
+#' shot models. Tracked in internal project notes
+#' (`project_clean_pbp_sign_flip_cascade`) and the corresponding GitHub
+#' issue.
+#'
 #' @param dt A data.table to modify
 #' @return Invisible NULL (modifies dt by reference)
 #' @keywords internal
 fix_chain_coordinates_dt <- function(dt) {
+  # TODO(clean_pbp-sign-flip-cascade): see roxygen above. Iterative
+  # corrections below can mis-flip ~7% of shot rows from positive to
+  # negative x. Band-aid lives in add_shot_geometry_variables for display
+  # purposes only; real fix needs algorithm rework + model retraining.
   # Warn if any rows have NA team_id_mdl (coordinates can't be fixed for these)
   na_team_count <- sum(is.na(dt$team_id_mdl))
   if (na_team_count > 0L) {

--- a/R/wp_credit.R
+++ b/R/wp_credit.R
@@ -38,7 +38,7 @@ create_wp_credit <- function(pbp_data = NULL,
 
   required_cols <- c("wpa", "player_id", "player_name", "lead_player_id",
                      "pos_team", "display_order", "match_id", "team",
-                     "utc_start_time", "round_number")
+                     "utc_start_time", "round_number", "description")
   missing <- setdiff(required_cols, names(pbp_data))
   if (length(missing) > 0) {
     cli::cli_abort("Missing required columns: {.val {missing}}")
@@ -46,9 +46,19 @@ create_wp_credit <- function(pbp_data = NULL,
 
   dt <- data.table::setDT(data.table::copy(pbp_data))
 
-  # Filter to rows with a valid player and non-NA wpa
+  # Filter to rows with a valid player and non-NA wpa, AND exclude descriptive
+  # scoring rows ("Goal" / "Behind" / "Rushed"). Those rows are chain
+  # bookkeeping — the actual scoring action (Kick with shot_at_goal == 1) is
+  # the previous row and already gets full WPA credit through the next-row
+  # WP delta. Including them would double-count the scoring player and import
+  # their anomalous post-score wp (computed against a half-updated score state)
+  # into the credit aggregation. The worker's per-row WPA pipeline
+  # (worker/src/score-tracker.js::attachAflWpa in inthegame-blog) filters to
+  # "relevant" rows the same way, so excluding here aligns torp parquet WPA
+  # with the chain-summed WPA the blog renders for live/CFS-fallback matches.
 
-  dt <- dt[!is.na(player_id) & !is.na(wpa)]
+  dt <- dt[!is.na(player_id) & !is.na(wpa) &
+           !(description %in% c("Goal", "Behind", "Rushed"))]
 
   # Determine if receiver exists and is different from disposer
   # No receiver when: lead_player_id is NA, equals player_id, or is a shot/OOB

--- a/R/wp_credit.R
+++ b/R/wp_credit.R
@@ -51,7 +51,7 @@ create_wp_credit <- function(pbp_data = NULL,
   # pipeline strips them upstream in clean_model_data_epv() via the
   # EPV_RELEVANT_DESCRIPTIONS whitelist. This guard exists for direct callers
   # that bypass that step. See project_wpa_reconciliation_b4 in memory for the
-  # full investigation — the chain-sum vs parquet WPA gap is a WP-model
+  # full investigation -- the chain-sum vs parquet WPA gap is a WP-model
   # divergence (worker's chain-aware features produce larger per-row deltas),
   # not a filter or attribution issue.
   dt <- dt[!is.na(player_id) & !is.na(wpa) &

--- a/R/wp_credit.R
+++ b/R/wp_credit.R
@@ -46,17 +46,14 @@ create_wp_credit <- function(pbp_data = NULL,
 
   dt <- data.table::setDT(data.table::copy(pbp_data))
 
-  # Filter to rows with a valid player and non-NA wpa, AND exclude descriptive
-  # scoring rows ("Goal" / "Behind" / "Rushed"). Those rows are chain
-  # bookkeeping — the actual scoring action (Kick with shot_at_goal == 1) is
-  # the previous row and already gets full WPA credit through the next-row
-  # WP delta. Including them would double-count the scoring player and import
-  # their anomalous post-score wp (computed against a half-updated score state)
-  # into the credit aggregation. The worker's per-row WPA pipeline
-  # (worker/src/score-tracker.js::attachAflWpa in inthegame-blog) filters to
-  # "relevant" rows the same way, so excluding here aligns torp parquet WPA
-  # with the chain-summed WPA the blog renders for live/CFS-fallback matches.
-
+  # Defensive: descriptive scoring rows ("Goal" / "Behind" / "Rushed") would
+  # over-credit the scorer if they reached this aggregation, but the standard
+  # pipeline strips them upstream in clean_model_data_epv() via the
+  # EPV_RELEVANT_DESCRIPTIONS whitelist. This guard exists for direct callers
+  # that bypass that step. See project_wpa_reconciliation_b4 in memory for the
+  # full investigation — the chain-sum vs parquet WPA gap is a WP-model
+  # divergence (worker's chain-aware features produce larger per-row deltas),
+  # not a filter or attribution issue.
   dt <- dt[!is.na(player_id) & !is.na(wpa) &
            !(description %in% c("Goal", "Behind", "Rushed"))]
 

--- a/man/add_shot_geometry_variables.Rd
+++ b/man/add_shot_geometry_variables.Rd
@@ -7,7 +7,10 @@
 add_shot_geometry_variables(df, goal_width)
 }
 \arguments{
-\item{df}{A dataframe containing shot data.}
+\item{df}{A dataframe containing shot data. Pass \code{venue_length} to enable
+the near-goal fold (recommended for any production caller). Without it,
+\code{goal_x} is used as-is, which assumes the caller has already mirrored
+coordinates to be positive — only suitable for synthetic test fixtures.}
 
 \item{goal_width}{The width of the goal.}
 }
@@ -15,14 +18,27 @@ add_shot_geometry_variables(df, goal_width)
 A dataframe with additional shot geometry variables.
 }
 \description{
-Computes side_b, side_c, angle, and distance to the attacking goal.
-Internally folds \code{goal_x} to the near-goal distance: a player at x = -30
-on a 165m field has goal_x = halfLen - x = 112.5 (signed), but the actual
-distance to the goal they're attacking is 52.5m. Pre-fold, shots from
-negative-x reported distance to the FAR goal — visible on the blog as e.g.
-a 126m behind that should have been 40m. The fold uses venue_length when
-available; tests / legacy callers without venue_length fall through to
-the raw goal_x (which assumes coords are already pre-mirrored to be
-positive).
+Computes shot \code{angle} and \code{distance} to the attacking goal (plus
+intermediate trig legs \code{side_b} / \code{side_c}).
+}
+\details{
+BAND-AID: when \code{venue_length} is in \code{names(df)}, \code{goal_x} is folded to the
+near-goal distance via \code{pmin(goal_x, venue_length - goal_x)} before the
+geometry calculation. This is NOT a coordinate-frame fix — it works around
+an upstream issue where \code{clean_pbp::fix_chain_coordinates_dt} mis-flips
+~7\% of shot_at_goal rows from positive to negative \code{x} (the iterative
+neighbour-based sign-flip cascades from a wrong anchor row when there's
+API noise in the chain). Without the fold, those rows render as e.g. 126m
+behinds when the truth is ~40m. The fold only corrects user-facing
+\code{distance} / \code{angle}; the underlying \code{x} and \code{goal_x} columns remain
+wrong for those rows, which is fine because the EP/WP/shot models were
+trained on the same buggy \code{x} and are internally consistent with it.
+See \code{project_clean_pbp_sign_flip_cascade} in memory for the full
+investigation and the path to a proper upstream fix (model retraining
+required).
+
+Side effect: the rare ~0.2\% of genuine long-range shots from own half
+(real \code{x < 0} cases per CLAUDE.md's team-relative coords) will also be
+folded to near-goal distance. Acceptable trade-off vs the 7\% mis-flip.
 }
 \keyword{internal}

--- a/man/add_shot_geometry_variables.Rd
+++ b/man/add_shot_geometry_variables.Rd
@@ -10,7 +10,7 @@ add_shot_geometry_variables(df, goal_width)
 \item{df}{A dataframe containing shot data. Pass \code{venue_length} to enable
 the near-goal fold (recommended for any production caller). Without it,
 \code{goal_x} is used as-is, which assumes the caller has already mirrored
-coordinates to be positive — only suitable for synthetic test fixtures.}
+coordinates to be positive -- only suitable for synthetic test fixtures.}
 
 \item{goal_width}{The width of the goal.}
 }
@@ -24,7 +24,7 @@ intermediate trig legs \code{side_b} / \code{side_c}).
 \details{
 BAND-AID: when \code{venue_length} is in \code{names(df)}, \code{goal_x} is folded to the
 near-goal distance via \code{pmin(goal_x, venue_length - goal_x)} before the
-geometry calculation. This is NOT a coordinate-frame fix — it works around
+geometry calculation. This is NOT a coordinate-frame fix -- it works around
 an upstream issue where \code{clean_pbp::fix_chain_coordinates_dt} mis-flips
 a small fraction of shot_at_goal rows from positive to negative \code{x} (the
 iterative neighbour-based sign-flip cascades from a wrong anchor row when

--- a/man/add_shot_geometry_variables.Rd
+++ b/man/add_shot_geometry_variables.Rd
@@ -26,19 +26,22 @@ BAND-AID: when \code{venue_length} is in \code{names(df)}, \code{goal_x} is fold
 near-goal distance via \code{pmin(goal_x, venue_length - goal_x)} before the
 geometry calculation. This is NOT a coordinate-frame fix — it works around
 an upstream issue where \code{clean_pbp::fix_chain_coordinates_dt} mis-flips
-~7\% of shot_at_goal rows from positive to negative \code{x} (the iterative
-neighbour-based sign-flip cascades from a wrong anchor row when there's
-API noise in the chain). Without the fold, those rows render as e.g. 126m
-behinds when the truth is ~40m. The fold only corrects user-facing
-\code{distance} / \code{angle}; the underlying \code{x} and \code{goal_x} columns remain
-wrong for those rows, which is fine because the EP/WP/shot models were
-trained on the same buggy \code{x} and are internally consistent with it.
-See \code{project_clean_pbp_sign_flip_cascade} in memory for the full
-investigation and the path to a proper upstream fix (model retraining
-required).
+a small fraction of shot_at_goal rows from positive to negative \code{x} (the
+iterative neighbour-based sign-flip cascades from a wrong anchor row when
+there's API noise in the chain). On 2026 R1 chain data the mis-flip rate
+on shots was ~7\% post-\code{clean_pbp} vs ~0.2\% in raw chains. Without the
+fold, those rows render as e.g. 126m behinds when the truth is ~40m. The
+fold only corrects user-facing \code{distance} / \code{angle}; the underlying \code{x}
+and \code{goal_x} columns remain wrong for those rows, which is fine because
+the EP/WP/shot models were trained on the same buggy \code{x} and are
+internally consistent with it. The full investigation and path to a
+proper upstream fix (model retraining required) is tracked in the
+internal \code{project_clean_pbp_sign_flip_cascade} notes; root-cause file
+is \code{R/clean_pbp.R::fix_chain_coordinates_dt}.
 
-Side effect: the rare ~0.2\% of genuine long-range shots from own half
-(real \code{x < 0} cases per CLAUDE.md's team-relative coords) will also be
-folded to near-goal distance. Acceptable trade-off vs the 7\% mis-flip.
+Side effect: genuine long-range shots from own half (real \code{x < 0} cases
+per CLAUDE.md's team-relative coords; ~0.2\% of shots in measured data)
+also get folded to near-goal distance. Acceptable trade-off vs the
+mis-flip case.
 }
 \keyword{internal}

--- a/man/fix_chain_coordinates_dt.Rd
+++ b/man/fix_chain_coordinates_dt.Rd
@@ -17,4 +17,18 @@ Converts coordinates to pitch-relative (home-team) space, fixes unreasonable
 jumps around throw-ins and ambiguous possession events, then converts back to
 possession-team perspective.
 }
+\details{
+Known limitation: the iterative neighbour-based sign-flip routine in
+steps C-F can cascade from a wrong anchor row when there's API noise
+(duplicate / oscillating chain rows), wrongly flipping a chain of
+correctly-positioned rows to match an outlier predecessor. Empirically
+affects ~7\% of shot_at_goal rows. \code{R/clean_features.R::add_shot_geometry_variables}
+folds the resulting bad \code{goal_x} to a near-goal distance as a downstream
+band-aid for user-facing display, but the underlying \code{x} is still wrong
+for those rows (consumed by EP/WP/shot models). A proper fix needs
+rework of the correction algorithm AND retraining of the EP, WP, and
+shot models. Tracked in internal project notes
+(\code{project_clean_pbp_sign_flip_cascade}) and the corresponding GitHub
+issue.
+}
 \keyword{internal}

--- a/tests/testthat/test-clean-pbp-pipeline.R
+++ b/tests/testthat/test-clean-pbp-pipeline.R
@@ -430,6 +430,25 @@ test_that("add_shot_geometry_variables folds goal_x for shots from negative-x", 
   expect_equal(result$distance[2], 52.5)
 })
 
+test_that("add_shot_geometry_variables warns on NA venue_length", {
+  # NA venue_length silently produces NA goal_x_near → NaN angle → NA distance,
+  # poisoning every downstream feature. Warn rather than swallow.
+  mock_data <- data.frame(
+    x = c(50, -30),
+    y = c(0, 0),
+    goal_x = c(32.5, 112.5),
+    venue_length = c(165, NA_real_),
+    stringsAsFactors = FALSE
+  )
+
+  expect_warning(
+    result <- torp:::add_shot_geometry_variables(mock_data, goal_width = 6.4),
+    "NA"
+  )
+  expect_equal(result$distance[1], 32.5)
+  expect_true(is.na(result$distance[2]))
+})
+
 test_that("add_shot_geometry_variables falls through without venue_length", {
   # Legacy callers pass pre-mirrored coordinates (always positive goal_x);
   # without venue_length the function should use raw goal_x unchanged.

--- a/tests/testthat/test-clean-pbp-pipeline.R
+++ b/tests/testthat/test-clean-pbp-pipeline.R
@@ -425,10 +425,25 @@ test_that("add_shot_geometry_variables folds goal_x for shots from negative-x", 
 
   result <- torp:::add_shot_geometry_variables(mock_data, goal_width = 6.4)
 
-  # Positive-x shot: unchanged (32.5m)
-  expect_equal(result$distance[1], 32.5, tolerance = 0.1)
-  # Negative-x shot: folded to the near goal (52.5m, not the buggy 112.5m)
-  expect_equal(result$distance[2], 52.5, tolerance = 0.1)
+  # With y = 0, distance = goal_x_near exactly (no trig, exact arithmetic)
+  expect_equal(result$distance[1], 32.5)
+  expect_equal(result$distance[2], 52.5)
+})
+
+test_that("add_shot_geometry_variables falls through without venue_length", {
+  # Legacy callers pass pre-mirrored coordinates (always positive goal_x);
+  # without venue_length the function should use raw goal_x unchanged.
+  mock_data <- data.frame(
+    goal_x = c(32.5, 52.5),
+    y = c(0, 0),
+    stringsAsFactors = FALSE
+  )
+
+  result <- torp:::add_shot_geometry_variables(mock_data, goal_width = 6.4)
+
+  expect_equal(result$distance[1], 32.5)
+  expect_equal(result$distance[2], 52.5)
+  expect_false("goal_x_near" %in% names(result))
 })
 
 # -----------------------------------------------------------------------------

--- a/tests/testthat/test-clean-pbp-pipeline.R
+++ b/tests/testthat/test-clean-pbp-pipeline.R
@@ -441,9 +441,13 @@ test_that("add_shot_geometry_variables warns on NA venue_length", {
     stringsAsFactors = FALSE
   )
 
+  # Match on the specific message AND pin the count to "1" so a regression in
+  # the predicate (e.g., double-counting unrelated NA goal_x rows) would
+  # change the count and fail the test instead of slipping through a loose
+  # "NA" substring match.
   expect_warning(
     result <- torp:::add_shot_geometry_variables(mock_data, goal_width = 6.4),
-    "NA"
+    "1 row has NA.*venue_length"
   )
   expect_equal(result$distance[1], 32.5)
   expect_true(is.na(result$distance[2]))

--- a/tests/testthat/test-wp-credit.R
+++ b/tests/testthat/test-wp-credit.R
@@ -12,7 +12,8 @@ make_wp_pbp <- function(n = 10) {
     match_id = "M001",
     team = "TeamA",
     utc_start_time = "2025-04-01T14:00",
-    round_number = 1L
+    round_number = 1L,
+    description = "Kick"
   )
 }
 
@@ -40,7 +41,8 @@ test_that("create_wp_credit splits credit by disp_share", {
     match_id = "M001",
     team = "TeamA",
     utc_start_time = "2025-04-01T14:00",
-    round_number = 1L
+    round_number = 1L,
+    description = "Handball"
   )
 
   result <- create_wp_credit(pbp, disp_share = 0.6)
@@ -62,7 +64,8 @@ test_that("create_wp_credit gives 100% to disposer when no receiver", {
     match_id = "M001",
     team = "TeamA",
     utc_start_time = "2025-04-01T14:00",
-    round_number = 1L
+    round_number = 1L,
+    description = "Kick"
   )
 
   result <- create_wp_credit(pbp, disp_share = 0.5)
@@ -84,7 +87,8 @@ test_that("create_wp_credit flips receiver credit on turnovers", {
     match_id = "M001",
     team = "TeamA",
     utc_start_time = "2025-04-01T14:00",
-    round_number = 1L
+    round_number = 1L,
+    description = "Kick"
   )
 
   result <- create_wp_credit(pbp, disp_share = 0.5)
@@ -121,7 +125,8 @@ test_that("create_wp_credit identifies peak play correctly", {
     match_id = "M001",
     team = "TeamA",
     utc_start_time = "2025-04-01T14:00",
-    round_number = 1L
+    round_number = 1L,
+    description = "Kick"
   )
 
   result <- create_wp_credit(pbp)
@@ -142,7 +147,8 @@ test_that("create_wp_credit aggregates across multiple games", {
     match_id = c("M001", "M002"),
     team = "TeamA",
     utc_start_time = c("2025-04-01T14:00", "2025-04-08T14:00"),
-    round_number = c(1L, 2L)
+    round_number = c(1L, 2L),
+    description = "Kick"
   )
 
   result <- create_wp_credit(pbp)
@@ -150,4 +156,46 @@ test_that("create_wp_credit aggregates across multiple games", {
   expect_equal(nrow(result), 2L)
   expect_equal(result[match_id == "M001"]$wp_credit, 0.10)
   expect_equal(result[match_id == "M002"]$wp_credit, 0.20)
+})
+
+test_that("create_wp_credit excludes descriptive Goal/Behind/Rushed rows", {
+  # B4 defensive filter: descriptive scoring rows should not contribute to
+  # credit. The standard pipeline strips them upstream via
+  # EPV_RELEVANT_DESCRIPTIONS, but this guard handles direct callers.
+  pbp <- data.table::data.table(
+    wpa = c(0.10, 0.05, 0.07),
+    player_id = c("P1", "P1", "P1"),
+    player_name = "Alice",
+    lead_player_id = c(NA_character_, NA_character_, NA_character_),
+    pos_team = c(1L, 1L, 1L),
+    display_order = c(1L, 2L, 3L),
+    match_id = "M001",
+    team = "TeamA",
+    utc_start_time = "2025-04-01T14:00",
+    round_number = 1L,
+    description = c("Kick", "Goal", "Behind")
+  )
+
+  result <- create_wp_credit(pbp)
+
+  # Only the Kick row should be credited; Goal + Behind rows excluded.
+  expect_equal(result$wp_credit, 0.10)
+  expect_equal(result$n_disposals, 1L)
+})
+
+test_that("create_wp_credit errors when description column missing", {
+  pbp <- data.table::data.table(
+    wpa = 0.10,
+    player_id = "P1",
+    player_name = "Alice",
+    lead_player_id = NA_character_,
+    pos_team = 1L,
+    display_order = 1L,
+    match_id = "M001",
+    team = "TeamA",
+    utc_start_time = "2025-04-01T14:00",
+    round_number = 1L
+  )
+
+  expect_error(create_wp_credit(pbp), "description")
 })


### PR DESCRIPTION
## Summary

- **Fix shot distance for shots from negative-x** (2bb3052) — `add_shot_geometry_variables` runs before the chain mirror transform flips negative-x coordinates, so shots from `x < 0` had `goal_x > halfLen` and rendered as distance-to-opposite-goal (e.g. a Toby Greene behind at SCG R6 2026 SYD vs GWS came through as 126m instead of ~40m). Folded `goal_x` to the near-goal distance via `pmin(goal_x, venue_length - goal_x)` when `venue_length` is available; legacy callers without it fall through unchanged.
- **Defensive filter in `create_wp_credit()`** (de2fe6b + 7ffdb3d) — exclude descriptive scoring rows (\"Goal\" / \"Behind\" / \"Rushed\") from the per-player WPA aggregation, and require `description` in input columns. In the standard pipeline this is a no-op (verified: 0 rows excluded across all 46 players in `CD_M20260141002`) because `clean_model_data_epv()` already strips these rows via `EPV_RELEVANT_DESCRIPTIONS`. It exists as a fail-loud guard for any future caller that hits `create_wp_credit()` directly with un-EPV-filtered chains. The accompanying comment rewrite honestly describes this — the original commit message had implied this fix would close the chain-sum vs parquet WPA reconciliation gap, which it does not.

## Notes on the WPA reconciliation gap

The +33.5% (worker chain-sum) vs +14% (torp parquet) gap for Logan McDonald's SYD vs COL R10 game is a WP-model divergence, not a filter or attribution bug:

- Both pipelines apply the same 50/50 disposer/receiver credit split.
- The worker's per-row \`wpa\` values are ~2× torp's on the same chain rows because its model has chain-aware features (\`exp_pts\`, \`shot_row\`, \`chain_action_num\`, \`phase_of_play_*\`) that torp's WP model doesn't. On Logan's Q4 goal sequence: worker LBG row wpa = +27pp vs torp +4pp; worker Kick row wpa = +5pp vs torp +9pp. End-to-end Sydney WP swing is similar (~13pp vs ~32pp), but the path between rows differs.
- Closing the gap requires either porting torp's R WP model into the inthegame-blog worker, or retraining torp's WP with chain-aware features. Multi-week project, out of scope. Memory note \`project_wpa_reconciliation_b4\` has the full diagnosis.

## Test plan

- [x] Verified B4 filter is a no-op in the standard pipeline on `CD_M20260141002` (max |old vs new wp_credit| delta = 8.3e-17 across 46 players)
- [x] Walked Logan McDonald's Q3 + Q4 scoring chains row-by-row to confirm torp's per-row wpa and final wp_credit reconcile (+0.1407 ≈ published +0.130)
- [ ] CI: \`R CMD check\` clean
- [ ] CI: pkgdown builds