### PR TITLE
fix(#88 feed) full-history PSR in ratings blend + #87 skills-history build

### DIFF
--- a/data-raw/03-ratings/run_ratings_pipeline.R
+++ b/data-raw/03-ratings/run_ratings_pipeline.R
@@ -367,9 +367,13 @@ if (nrow(torp_new) > 0) {
     torp_df_total <- torp_new
   }
 
-  # Blend PSR into ratings so the release has torp/psr/osr/dsr columns
+  # Blend PSR into ratings so the release has torp/psr/osr/dsr columns.
+  # torp_df_total is always the full historical table (upserted into the
+  # existing release above), so PSR must cover ALL seasons too -- otherwise
+  # historical rows find no per-round match in calculate_torp() and fall back
+  # to the current snapshot, leaving psr/osr/dsr flat across history (#88).
   psr_df <- tryCatch({
-    stat_ratings <- load_player_stat_ratings()
+    stat_ratings <- load_player_stat_ratings(TRUE)
     .compute_psr_from_stat_ratings(stat_ratings)
   }, error = function(e) {
     cli::cli_warn("Could not compute PSR for release: {e$message}")

--- a/data-raw/06-stat-ratings/build_skills_history.R
+++ b/data-raw/06-stat-ratings/build_skills_history.R
@@ -1,0 +1,122 @@
+# build_skills_history.R  — issue #87
+# ============================================================
+# Produce a single per-round, per-player, per-season historical snapshot of all
+# skill (*_rating) columns for the blog AFL Age Curves page.
+#
+# KEY INSIGHT (verified 2026-06-18): the per-round historical stat ratings are
+# ALREADY computed and released. `03_estimate_stat_ratings.R` calls
+# `.estimate_stat_ratings_batch()` for every (season, round) ref_date across ALL
+# seasons the source supports, and `04_export_stat_ratings.R` uploads them
+# per-season to the `player_stat_ratings-data` release
+# (player_stat_ratings_<season>.parquet, 2021..current). Confirmed identical
+# 234-col / 56 *_rating-col schema to the `player_skills_<year>.parquet` the blog
+# already consumes — so the history file is column-compatible by construction.
+#
+# This issue is therefore a PACKAGING change, not a recompute:
+#   - The blog only ever ships the CURRENT-year file (build-blog-data.yml pulls
+#     player_skills_${YEAR}.parquet -> player-skills.parquet).
+#   - We concatenate every season's per-round table, keep only the *_rating
+#     columns (+ id/metadata) to control file size, and publish it as a single
+#     `player_skills_history.parquet` into the existing player_skills-data
+#     release (keeps the blog's download step in one place).
+#
+# Run AFTER 03_estimate_stat_ratings.R (which writes the cache rds), OR let it
+# pull the already-published per-season parquets straight from the release
+# (default when the local cache is absent).
+#
+# Local output: data-raw/cache-stat-ratings/player_skills_history.parquet
+# Release      : player_skills-data  ->  player_skills_history.parquet
+#
+# DRY_RUN = TRUE (default) writes the local parquet but does NOT upload.
+# Set DRY_RUN = FALSE (or env TORP_SKILLS_HISTORY_PUBLISH=1) to publish.
+# ------------------------------------------------------------
+
+suppressMessages({
+  library(arrow)
+  library(data.table)
+})
+
+DRY_RUN <- !identical(Sys.getenv("TORP_SKILLS_HISTORY_PUBLISH"), "1")
+
+src_release <- "player_stat_ratings-data"   # source: per-season per-round history
+out_release <- "player_skills-data"         # target: blog download step lives here
+out_stem    <- "player_skills_history"
+
+cache_dir <- file.path("data-raw", "cache-stat-ratings")
+dir.create(cache_dir, showWarnings = FALSE, recursive = TRUE)
+out_path  <- file.path(cache_dir, paste0(out_stem, ".parquet"))
+
+# --- Source: prefer local cache rds from 03_, else download release parquets ---
+cache_rds <- file.path(cache_dir, "03_player_stat_ratings.rds")
+
+if (file.exists(cache_rds)) {
+  cli::cli_inform("Reading per-round ratings from local cache {.path {cache_rds}}")
+  all_ratings <- data.table::as.data.table(readRDS(cache_rds))
+} else {
+  cli::cli_inform("Local cache absent - downloading per-season parquets from {.val {src_release}}")
+  dl_dir <- file.path(cache_dir, "_history_src")
+  dir.create(dl_dir, showWarnings = FALSE, recursive = TRUE)
+  # Plain args (no shQuote): gh handles the glob; avoids Windows single-quote issues.
+  status <- system2("gh", c("release", "download", src_release,
+                            "-R", "peteowen1/torpdata",
+                            "-p", "player_stat_ratings_*.parquet",
+                            "-D", dl_dir, "--clobber"))
+  if (!identical(status, 0L)) {
+    cli::cli_abort("gh release download failed (exit {status}). Is gh authenticated?")
+  }
+  files <- list.files(dl_dir, pattern = "^player_stat_ratings_\\d{4}\\.parquet$",
+                      full.names = TRUE)
+  if (length(files) == 0) cli::cli_abort("No per-season parquets downloaded.")
+  cli::cli_inform("Concatenating {length(files)} season file{?s}")
+  all_ratings <- data.table::rbindlist(lapply(files, arrow::read_parquet),
+                                       fill = TRUE)
+}
+
+cli::cli_inform("Loaded {nrow(all_ratings)} player-round rows, {ncol(all_ratings)} cols")
+cli::cli_inform("Seasons: {paste(sort(unique(all_ratings$season)), collapse = ', ')}")
+
+# --- Keep id/metadata + every *_rating column; drop the _raw/_n80s/_wt80s/
+#     _attempts sidecars. Verified ~2.6x size cut (30MB -> ~11MB/season). ---
+nm <- names(all_ratings)
+meta_cols   <- intersect(c("player_id", "player_name", "pos_group",
+                           "season", "round", "n_games", "wt_games"), nm)
+rating_cols <- nm[grepl("_rating$", nm)]
+keep_cols   <- c(meta_cols, rating_cols)
+
+history <- all_ratings[, keep_cols, with = FALSE]
+
+# Type hygiene for stable Arrow reads downstream
+history[, season := as.integer(season)]
+history[, round  := as.integer(round)]
+data.table::setcolorder(history, meta_cols)
+data.table::setorder(history, player_id, season, round)
+
+cli::cli_inform(
+  "History table: {nrow(history)} rows x {ncol(history)} cols ({length(rating_cols)} rating cols)"
+)
+
+# --- Sanity checks before publishing ---
+stopifnot(
+  nrow(history) > 50000,               # expect ~150-200k across seasons
+  length(rating_cols) >= 50,           # ~56 rating cols today
+  length(unique(history$season)) >= 4, # multi-season
+  !anyNA(history$player_id),
+  !anyNA(history$season),
+  !anyNA(history$round)
+)
+
+arrow::write_parquet(history, out_path)
+cli::cli_alert_success(
+  "Wrote {.path {out_path}} ({round(file.size(out_path) / 1048576, 1)} MB)"
+)
+
+# --- Publish to the player_skills-data release (single file, all seasons) ---
+if (DRY_RUN) {
+  cli::cli_alert_info(
+    "DRY_RUN: skipped upload. Set TORP_SKILLS_HISTORY_PUBLISH=1 to publish to {.val {out_release}}."
+  )
+} else {
+  devtools::load_all(quiet = TRUE)   # for save_to_release()
+  save_to_release(as.data.frame(history), out_stem, out_release)
+  cli::cli_alert_success("Published {out_stem}.parquet to {.val {out_release}}")
+}


### PR DESCRIPTION
Follow-up to #93. Two `data-raw` changes (no package/runtime code touched).

### `c5fc004` — fix #88 pipeline feed (the real fix)
The `calculate_torp()` join fixed in #93 was correct, but `run_ratings_pipeline.R:372` fed it `load_player_stat_ratings()` — which defaults to the **current season only**. Since `torp_df_total` is always the full historical table (upserted into the existing release), every historical row found no per-round PSR match and fell back to the snapshot → flat psr/osr/dsr across 2021–2025. (This is why the `seasons=TRUE` republish didn't fix history — that input drives the EPR loop, not this load.)

Fix: `load_player_stat_ratings(TRUE)`, mirroring the standalone PSR stage. **Verified locally** by replaying the blend against the published table: flat-PSR players **50.4% → 21.0%** (remainder are short-career players with few PSR points); Petracca 17 → 156 unique, Oscar McInerney 1 → 140. Needs a ratings republish to take effect.

### `fdda689` — #87 skills-history build (riding along)
Adds `data-raw/06-stat-ratings/build_skills_history.R` — assembles a per-round, per-player, per-season history of all 56 `*_rating` columns for the blog age-curves page, from the already-released per-season `player_stat_ratings-data`. Verified end-to-end (DRY_RUN): 176,055 rows, 2021–2026, 77.8 MB. Upload guarded behind `TORP_SKILLS_HISTORY_PUBLISH=1`. Downstream wiring (publish step + blog) is a follow-up.

### Safe to merge
Neither change runs on merge. The #88 fix only changes published numbers on the next manual ratings republish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)