### PR TITLE
feat(#92): AFL API field audit — capture dropped fields, dictionary, self-consistent orientation

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -18,4 +18,6 @@
 ^\.positai$
 ^\.wrangler$
 ^ARCHITECTURE\.md$
+^AFL-API-REFERENCE\.md$
 ^scripts$
+^\.positai$

--- a/AFL-API-REFERENCE.md
+++ b/AFL-API-REFERENCE.md
@@ -1,0 +1,528 @@
+# AFL API Reference (torp in-house client)
+
+Complete data dictionary for the in-house AFL API client that replaced
+`fitzRoy` in the `torp` package. Covers every endpoint the package fetches,
+its response structure, every field, and which torp table / release / loader
+each endpoint feeds.
+
+The fetch functions live in `R/afl_api.R` (structured fixture / result / lineup
+/ player-stats / player-detail endpoints) and `R/scraper.R` (chain PBP plus the
+internal round/player enumeration helpers). All endpoint field enumeration
+below was captured **live** on 2026-06-18 against the 2026 season
+(`compSeasonId = 85`, sample match `CD_M20260140603` Sydney v GWS R6).
+
+---
+
+## Base URLs and auth model
+
+Three base URLs, defined in `R/constants_afl.R`:
+
+| Constant | Value | Auth |
+|----------|-------|------|
+| `AFL_API_BASE_URL` | `https://aflapi.afl.com.au/afl/v2/` | **Public** — no token. Plain `httr::GET()`. |
+| `AFL_CFS_API_BASE_URL` | `https://api.afl.com.au/cfs/afl/` | **Token** — `x-media-mis-token` header. |
+| `AFL_SAPI_BASE_URL` | `https://sapi.afl.com.au/afl/` | **Token** — `x-media-mis-token` header. |
+
+**Auth flow** (`R/scraper.R`):
+- `get_token()` — POSTs `AFL_CFS_API_BASE_URL + "WMCTok"`, returns a bearer
+  token, cached 5 min in `.torp_token_cache`.
+- `access_api(url)` — GETs `url` with the `x-media-mis-token` header, parses
+  the JSON body with `jsonlite::fromJSON(flatten = TRUE)`. Used for CFS + SAPI
+  endpoints.
+- The public `aflapi.afl.com.au/afl/v2` endpoints need **no** auth — they use
+  bare `httr::GET()` or an unauthenticated `curl` pool.
+
+This in-house client replaced the external `fitzRoy` package: torp now scrapes
+the AFL's own apps' backend APIs directly.
+
+All parsers run `jsonlite::fromJSON(flatten = TRUE)`, so nested JSON objects
+become dot-notation columns (`home.team.name`). `.drop_list_cols()` then drops
+any remaining **list-columns** (nested arrays/data.frames) because Arrow/parquet
+cannot serialize them. Downstream, the `*_COL_MAP` rename maps + `.bulk_snake_case()`
+(in `R/column_schema.R`) convert these to canonical snake_case.
+
+---
+
+## Dropped fields brought through in this pass (changelog)
+
+Additive, low-risk captures added so the raw scraped tables faithfully archive
+the API. **Re-scrape implication:** each adds a new column to its release; no
+existing column changes. Verified live unless noted.
+
+| Endpoint | Fetch fn | New column(s) | Source field | Notes |
+|----------|----------|---------------|--------------|-------|
+| `matches` (fixtures) | `.fetch_fixtures_for_season_id` (`R/afl_api.R`) | `round_byes` | `matches[].round.byes` (list-col of bye-team data.frames) | Flattened to comma-separated team abbreviations. 63/207 fixtures populated (one per non-bye round). Verified. |
+| `squads` (player details) | `.parse_squad_json` (`R/afl_api.R`) | `team_id`, `team_abbreviation`, `team_nickname`, `team_team_type` | `squad.team.{id,abbreviation,nickname,teamType}` | Numeric team id + identity. `squad.team.club.*`, `squad.team.metadata.*` (social URLs), and `squad.compSeason.*` intentionally skipped (redundant/noise). Verified. |
+| `matchRoster/full` (lineups) | `.parse_match_roster` (`R/afl_api.R`) | `team_status` | `matchRoster.{home,away}Team.teamStatus` | Per-team lineup status (e.g. `FINAL_TEAM`). Verified through `get_afl_lineups()`. |
+| `matchPlays` (chains) | `get_game_chains` (`R/scraper.R`) | `homeTeamId`, `awayTeamId`, `chain_period_seconds` | top-level + `matchChains[].periodSeconds` | **Pre-existing** (done before this pass). `filter` (empty NULL query-echo) intentionally skipped. |
+
+Naming note: `team_team_type` is the literal snake_case of `team.teamType`
+(the `team.` prefix is preserved before snake-casing, mirroring how the existing
+`team.providerId` → `team_provider_id` mapping behaves). Renamed only where a
+genuine collision would otherwise occur; none did here.
+
+---
+
+## Endpoint: `competitions`  (public)
+
+**URL:** `AFL_API_BASE_URL + "competitions"`
+**Fetched by:** `.afl_all_comp_seasons()` (`R/afl_api.R:301`) — step 1 of resolving a season's numeric `compSeasonId`.
+
+Returns the list of AFL competitions. torp picks the row whose `code` is one of
+`AFL` / `AFLM` / `CD_AFLPrem` (the men's Toyota AFL Premiership), takes its `id`,
+and uses it for the `compseasons` call.
+
+**Nesting:** `{ meta: {code, pagination{page,numPages,pageSize,numEntries}}, competitions: data.frame }`
+
+| Field | Type | Description | Sample | Captured? |
+|-------|------|-------------|--------|-----------|
+| `competitions.id` | int | Numeric competition id | `1` | Used (not persisted) |
+| `competitions.providerId` | chr | Champion-Data provider id | `CD_C014` | Used (not persisted) |
+| `competitions.code` | chr | Competition code (filtered on) | `AFL` | Used (not persisted) |
+| `competitions.name` | chr | Competition display name | `Toyota AFL Premiership` | Used (not persisted) |
+| `meta.code` | int | HTTP-style status echo | `200` | No (transport meta) |
+| `meta.pagination.*` | int | Page / numPages / pageSize / numEntries | `numEntries=16` | No (transport meta) |
+
+**Feeds →** internal only. No torp table/release; consumed transiently to look up `compSeasonId`. Cached in-session as `afl_all_comp_seasons` / `afl_comp_season_id_<year>`.
+
+---
+
+## Endpoint: `competitions/{id}/compseasons`  (public)
+
+**URL:** `AFL_API_BASE_URL + "competitions/" + comp_id + "/compseasons"`
+**Fetched by:** `.afl_all_comp_seasons()` (`R/afl_api.R:334`) — step 2. Maps a 4-digit year to the AFL's numeric `compSeasonId` (e.g. 2026 → 85).
+
+**Nesting:** `{ meta{...}, compSeasons: data.frame }`
+
+| Field | Type | Description | Sample | Captured? |
+|-------|------|-------------|--------|-----------|
+| `compSeasons.id` | int | Numeric comp-season id (the value torp needs) | `85` | Used (not persisted) |
+| `compSeasons.providerId` | chr | Provider id encoding the year (`CD_S{year}014`) | `CD_S2026014` | Used (year parsed) |
+| `compSeasons.name` | chr | Season display name | `2026 Toyota AFL Premiership` | Used (not persisted) |
+| `compSeasons.shortName` | chr | Short label | `Premiership` | No |
+| `compSeasons.currentRoundNumber` | int | The round the season is currently up to | `15` | No |
+| `meta.*` | — | Transport metadata + pagination | `code=200` | No |
+
+**Feeds →** internal only. `id` becomes `compSeasonId` for the `matches` and `squads` calls. The `id` is also used by `get_afl_fixtures(TRUE)` to iterate all seasons.
+
+---
+
+## Endpoint: `matches?compSeasonId={id}`  (public)  — FIXTURES / RESULTS
+
+**URL:** `AFL_API_BASE_URL + "matches?compSeasonId=" + season_id + "&pageSize=1000"`
+**Fetched by:** `.fetch_fixtures_for_season_id()` (`R/afl_api.R:579`), via `get_afl_fixtures()` / `get_afl_results()` / `get_afl_ladder()`.
+
+Single call per season returns every match with **scores included** for
+concluded games — so `get_afl_results()` needs zero extra calls (filters
+`status == "CONCLUDED"`) and `get_afl_ladder()` computes standings from these.
+
+**Nesting:** `{ meta{...,pagination}, matches: data.frame (57 flattened cols) }`.
+Exactly one list-column, `round.byes`; all other 56 fields are scalar and are
+captured. After this pass, `round.byes` is flattened to `round_byes` before being
+dropped.
+
+Column names below are the **raw** flattened API names; the canonical torp name
+(after `.normalise_fixture_columns()` → `FIXTURE_COL_MAP` + snake_case) is given
+in the Description where it differs.
+
+| Field (raw) | Type | Description (→ canonical) | Sample | Captured? |
+|-------------|------|----------------------------|--------|-----------|
+| `id` | int | Numeric match id | `8041` | Yes (`id`) |
+| `providerId` | chr | Match provider id → `match_id` | `CD_M20260140001` | Yes |
+| `utcStartTime` | chr | Match start (UTC) → `utc_start_time` | `2026-03-05T08:30:00.000+0000` | Yes |
+| `status` | chr | Match status (`SCHEDULED`/`CONCLUDED`...) | `CONCLUDED` | Yes |
+| `compSeason.id` | int | Numeric comp-season id → `comp_season_id` | `85` | Yes |
+| `compSeason.providerId` | chr | → `comp_season_provider_id`; year parsed → `season` | `CD_S2026014` | Yes |
+| `compSeason.name` | chr | → `comp_season_name` | `2026 Toyota AFL Premiership` | Yes |
+| `compSeason.shortName` | chr | → `comp_season_short_name` | `Premiership` | Yes |
+| `compSeason.currentRoundNumber` | int | → `comp_season_current_round_number` | `15` | Yes |
+| `round.id` | int | Numeric round id → `round_id` | `1343` | Yes |
+| `round.providerId` | chr | → `round_provider_id` | `CD_R202601400` | Yes |
+| `round.abbreviation` | chr | Round abbr (`OR` = Opening Round) → `round_abbreviation` | `OR` | Yes |
+| `round.name` | chr | → `round_name` | `Opening Round` | Yes |
+| `round.roundNumber` | int | → `round_number` (0 = Opening Round) | `0` | Yes |
+| `round.byes` | list&lt;df&gt; | Teams on the bye this round (id, providerId, name, abbreviation, nickname, teamType, club.*) | df of 8 teams | **Now captured** → `round_byes` (comma-joined abbreviations) |
+| `round.utcStartTime` | chr | Round window start → `round_utc_start_time` | `2026-03-05T08:30:00.000+0000` | Yes |
+| `round.utcEndTime` | chr | Round window end → `round_utc_end_time` | `2026-03-08T08:20:00.000+0000` | Yes |
+| `home.team.id` | int | Home numeric team id → `home_team_api_id` | `13` | Yes |
+| `home.team.providerId` | chr | → `home_team_id` | `CD_T160` | Yes |
+| `home.team.name` | chr | → `home_team_name` | `Sydney Swans` | Yes |
+| `home.team.abbreviation` | chr | → `home_team_abbreviation` | `SYD` | Yes |
+| `home.team.nickname` | chr | → `home_team_nickname` | `Swans` | Yes |
+| `home.team.teamType` | chr | → `home_team_team_type` (`MEN`) | `MEN` | Yes |
+| `home.team.club.id` | int | Club numeric id → `home_team_club_id` | `24` | Yes |
+| `home.team.club.providerId` | chr | → `home_team_club_provider_id` | `CD_O28` | Yes |
+| `home.team.club.name` | chr | → `home_team_club_name` | `Sydney Swans` | Yes |
+| `home.team.club.abbreviation` | chr | → `home_team_club_abbreviation` | `Swans` | Yes |
+| `home.team.club.nickname` | chr | → `home_team_club_nickname` | `Swans` | Yes |
+| `home.score.goals` | int | → `home_goals` | `20` | Yes |
+| `home.score.behinds` | int | → `home_behinds` | `12` | Yes |
+| `home.score.totalScore` | int | → `home_score` | `132` | Yes |
+| `home.score.superGoals` | int | Super-goals (AFLX/preseason) → `home_score_super_goals` | `0` | Yes |
+| `away.team.id` | int | → `away_team_api_id` | `5` | Yes |
+| `away.team.providerId` | chr | → `away_team_id` | `CD_T30` | Yes |
+| `away.team.name` | chr | → `away_team_name` | `Carlton` | Yes |
+| `away.team.abbreviation` | chr | → `away_team_abbreviation` | `CARL` | Yes |
+| `away.team.nickname` | chr | → `away_team_nickname` | `Blues` | Yes |
+| `away.team.teamType` | chr | → `away_team_team_type` | `MEN` | Yes |
+| `away.team.club.*` | int/chr | Away club id/providerId/name/abbreviation/nickname | `CD_O5` | Yes (all 5) |
+| `away.score.goals` | int | → `away_goals` | `10` | Yes |
+| `away.score.behinds` | int | → `away_behinds` | `9` | Yes |
+| `away.score.totalScore` | int | → `away_score` | `69` | Yes |
+| `away.score.superGoals` | int | → `away_score_super_goals` | `0` | Yes |
+| `venue.id` | int | → `venue_id` | `9` | Yes |
+| `venue.providerId` | chr | → `venue_provider_id` | `CD_V60` | Yes |
+| `venue.name` | chr | → `venue_name` | `SCG` | Yes |
+| `venue.abbreviation` | chr | → `venue_abbreviation` | `SCG` | Yes |
+| `venue.location` | chr | City → `venue_location` | `Sydney` | Yes |
+| `venue.state` | chr | → `venue_state` | `NSW` | Yes |
+| `venue.timezone` | chr | → `venue_timezone` | `Australia/Sydney` | Yes |
+| `venue.landOwner` | chr | Traditional land owner → `venue_land_owner` | `Gadigal` | Yes |
+| `metadata.prematch_label` | chr | → `metadata_prematch_label` | `Opening Round` | Yes |
+| `metadata.ticket_link` | chr | → `metadata_ticket_link` | `https://...` | Yes |
+| `metadata.sold_out` | (varies) | → `metadata_sold_out` (present some calls) | — | Yes (when present) |
+
+Derived columns added downstream: `season` (from `compSeason.providerId`).
+
+**Feeds →**
+- `get_afl_fixtures()` → daily pipeline → torpdata **`fixtures-data`** release → `load_fixtures()`.
+- `get_afl_results()` (filter `CONCLUDED`) → **`results-data`** release → `load_results()`.
+- `get_afl_ladder()` → `calculate_ladder()` (in-memory; standings).
+- Field normalisation map: `FIXTURE_COL_MAP` (`R/column_schema.R:221`).
+
+---
+
+## Endpoint: `squads?teamId={tid}&compSeasonId={id}`  (public)  — PLAYER DETAILS
+
+**URL:** `AFL_API_BASE_URL + "squads?teamId=" + team_id + "&compSeasonId=" + season_id`
+**Fetched by:** `.parse_squad_json()` via `get_afl_player_details()` (`R/afl_api.R:845`) and `.fetch_all_player_details()`. One call per team (18) per season, fired in a parallel `curl` pool.
+
+`teamId` here is the **numeric** team id (e.g. `13`), not the `CD_T160`
+providerId (passing the providerId returns HTTP 400).
+
+**Nesting:** `{ meta{code}, squad: { compSeason{...}, team{...}, players: data.frame (14 cols) } }`
+
+### `squad.players` (player-level, the row grain)
+
+| Field (raw) | Type | Description (→ canonical) | Sample | Captured? |
+|-------------|------|----------------------------|--------|-----------|
+| `jumperNumber` | int | Squad jumper number → `jumper_number` | `2` | Yes |
+| `position` | chr | Listed position class | `KEY_FORWARD` | Yes |
+| `player.id` | int | Numeric player id → `id` | `1956` | Yes |
+| `player.providerId` | chr | Player provider id → `player_id` (+ `row_id`) | `CD_I1003203` | Yes |
+| `player.firstName` | chr | → `first_name` (+ `player_name`) | `Hayden` | Yes |
+| `player.surname` | chr | → `surname` | `McLean` | Yes |
+| `player.dateOfBirth` | chr | DOB → `date_of_birth` (+ `age` computed) | `1999-01-20` | Yes |
+| `player.draftYear` | chr | → `draft_year` | `2018` | Yes |
+| `player.heightInCm` | int | → `height_cm` | `197` | Yes |
+| `player.weightInKg` | int | → `weight_kg` (often 0 = unrecorded) | `0` | Yes |
+| `player.recruitedFrom` | chr | Recruiting club/pathway → `recruited_from` | `Beaumaris (Vic)/...` | Yes |
+| `player.debutYear` | chr | → `debut_year` | `2019` | Yes |
+| `player.draftType` | chr | → `draft_type` | `preseason` | Yes |
+| `player.draftPosition` | chr | → `draft_position` | `NA` | Yes |
+
+### `squad.team` (team identity — merged onto every player row)
+
+| Field (raw) | Type | Description (→ canonical) | Sample | Captured? |
+|-------------|------|----------------------------|--------|-----------|
+| `team.name` | chr | → `team` | `Sydney Swans` | Yes |
+| `team.providerId` | chr | → `team_provider_id` | `CD_T160` | Yes |
+| `team.id` | int | Numeric team id → `team_id` | `13` | **Now captured** |
+| `team.abbreviation` | chr | → `team_abbreviation` | `SYD` | **Now captured** |
+| `team.nickname` | chr | → `team_nickname` | `Swans` | **Now captured** |
+| `team.teamType` | chr | → `team_team_type` | `MEN` | **Now captured** |
+| `team.club.{id,providerId,name,abbreviation,nickname}` | int/chr | Parent club identity | `CD_O28` | No — redundant with team for AFL |
+| `team.metadata.{social_*Url,captainIds,clubSiteUrl,homeVenue}` | chr | Social media URLs, club captain ids, home venue | `SCG` | No — non-analytical noise |
+
+### `squad.compSeason` (season context)
+
+| Field | Type | Description | Sample | Captured? |
+|-------|------|-------------|--------|-----------|
+| `compSeason.{id,providerId,name,shortName,currentRoundNumber}` | int/chr | Season identity | `CD_S2026014` | No — redundant with the `season` column derived downstream |
+
+**Feeds →** `get_afl_player_details()` → **`player_details-data`** release (used by `load_player_details()`); also feeds `get_players(use_api = FALSE)` in `R/scraper.R` for chain joins. Map: `PLAYER_DETAILS_COL_MAP` (`R/column_schema.R:406`).
+
+---
+
+## Endpoint: `matchRoster/full/{match_id}`  (CFS, token)  — LINEUPS
+
+**URL:** `AFL_CFS_API_BASE_URL + "matchRoster/full/" + match_id`
+**Fetched by:** `.parse_match_roster()` via `get_afl_lineups()` (`R/afl_api.R:724`), one call per match through `.fetch_cfs_batch()`.
+
+The response is large and match-level; `.parse_match_roster()` reads only the
+**player rosters** (`matchRoster.{home,away}Team.positions`, 26 rows each = the
+named lineup) plus the team identity, producing a player-grained table. The
+many match-level branches (weather, umpires, recent form) are **not**
+player-grained and belong in other tables — see "intentionally left" below.
+
+**Top-level nesting:** `{ match{...}, venue{...}, matchRoster{...}, teamPlayers{...}, recentMatchScores{...} }`
+
+### Captured player-level fields (from `matchRoster.{home,away}Team.positions`)
+
+| Field (raw) | Type | Description (→ canonical) | Sample | Captured? |
+|-------------|------|----------------------------|--------|-----------|
+| `position` | chr | Named on-field position → `lineup_position` | `BPL` | Yes |
+| `player.playerId` | chr | → `player_id` (+ `row_id`) | `CD_I295222` | Yes |
+| `player.captain` | logi | → `captain` | `FALSE` | Yes |
+| `player.playerJumperNumber` | int | → `jumper_number` | `29` | Yes |
+| `player.playerName.givenName` | chr | → `given_name` | `Joel` | Yes |
+| `player.playerName.surname` | chr | → `surname` | `Hamling` | Yes |
+| *(added)* `teamId` | chr | Team provider id → `team_id` | `CD_T160` | Yes |
+| *(added)* `teamName` | chr | Team abbr → `team_abbr`; resolved → `team_name` | `SYD` | Yes |
+| *(added)* `teamType` | chr | `home`/`away` → `team_type` | `home` | Yes |
+| *(added)* `providerId` | chr | Match id → `match_id` | `CD_M20260140603` | Yes |
+| *(added)* `teamStatus` | chr | Lineup status → `team_status` | `FINAL_TEAM` | **Now captured** |
+
+Derived downstream: `season` (from `match_id`), `round_number` (from `match_id`).
+
+### Intentionally left (match-level, not player-grained)
+
+| Branch | Contents | Why not added here |
+|--------|----------|--------------------|
+| `match.*` | name, date, status, venue, home/awayTeamId, home/awayTeam{name,abbr,nickname,badgeAssetURL,flagAssetURL}, round, venueLocalStartTime, twitterHashTag | Match metadata duplicated in `fixtures-data`; asset URLs are non-analytical. |
+| `venue.*` | address, name, state, timeZone, venueId, abbreviation, landOwner (+ many NULL: capacity, groundDimension, lat/long, stadium links) | Venue dims belong to fixtures/venue refs; most fields NULL. |
+| `matchRoster.weather` | description, tempInCelsius, weatherType | Weather is sourced separately (Open-Meteo) into the `weather-data` release. |
+| `matchRoster.umpires` | df: umpireId, umpireType, umpireNumber, umpireName.{givenName,surname} | Umpire data is match-level; not part of the player roster grain. |
+| `matchRoster.{home,away}Team.{ins,outs}` | df: reason, player.* (selection ins/outs) | Late-change detail; team-level, separate concern. |
+| `matchRoster.{home,away}Team.{milestones,clubDebuts,lateChanges}` | usually empty / a free-text string | Sparse, free-text. |
+| `matchRoster.recentMatches` | df 5×28 — recent head-to-head form | Derived form data; reproducible from `results-data`. |
+| `teamPlayers` | df mirror of positions (with `photoURL`) | Duplicate of `positions` already captured. |
+| `recentMatchScores` | df 5×38 — period scores, score worm, score map, score chart | Rich match-summary data; reproducible from results / not roster-grained. |
+
+**Feeds →** `get_afl_lineups()` → daily lineup pipeline → torpdata **`teams-data`** release → `load_teams()` (and `load_lineups`-style joins). Map: `TEAMS_COL_MAP` (`R/column_schema.R:281`).
+
+---
+
+## Endpoint: `playerStats/match/{match_id}`  (CFS, token)  — PLAYER STATS
+
+**URL:** `AFL_CFS_API_BASE_URL + "playerStats/match/" + match_id`
+**Fetched by:** `.parse_match_stats()` via `get_afl_player_stats()` (`R/afl_api.R:779`), one call per concluded match through `.fetch_cfs_batch()`.
+
+**Nesting:** `{ homeTeamPlayerStats: data.frame (84 cols), awayTeamPlayerStats: data.frame (84 cols) }`.
+All 84 columns are scalar (no list-columns), so the parser keeps **every**
+field — only adding `teamStatus` (`home`/`away`) and `providerId`. The
+`playerStats.` prefix is stripped during parse; `.normalise_player_stats_columns()`
+then strips the `stats.`/`extendedStats.`/`clearances.` prefixes downstream.
+
+Below, raw flattened name → canonical after normalisation (prefix-stripped,
+snake_cased). The player-identity block appears **doubly nested**
+(`player.player.player.*`) because the endpoint embeds the roster player object
+inside the stats object; the parser deduplicates these.
+
+### Player identity
+
+| Field (raw) | Type | Canonical | Sample |
+|-------------|------|-----------|--------|
+| `teamId` | chr | `team_id` | `CD_T160` |
+| `player.jumperNumber` | int | `jumper_number` | `36` |
+| `player.photoURL` | chr | `photo_url` | `https://...` |
+| `player.player.position` | chr | `position` | `FPL` |
+| `player.player.player.playerId` | chr | `player_id` | `CD_I1008091` |
+| `player.player.player.captain` | logi | `captain` | `FALSE` |
+| `player.player.player.playerJumperNumber` | int | (dedup of jumper) | `36` |
+| `player.player.player.playerName.givenName` | chr | `given_name` | `Joel` |
+| `player.player.player.playerName.surname` | chr | `surname` | `Amartey` |
+| `playerStats.teamId` | chr | `team_id` (dedup) | `CD_T160` |
+| `playerStats.gamesPlayed` | logi | `games_played` (often NA) | `NA` |
+| `playerStats.timeOnGroundPercentage` | num | `time_on_ground_percentage` | `74` |
+| `playerStats.lastUpdated` | chr | `last_updated` | `2026-06-06T01:49:05.445+0000` |
+
+### Core stats (`playerStats.stats.*` → `*`)
+
+`goals, behinds, superGoals, kicks, handballs, disposals, marks, bounces,
+tackles, contestedPossessions, uncontestedPossessions, totalPossessions,
+inside50s, marksInside50, contestedMarks, hitouts, onePercenters,
+disposalEfficiency, clangers, freesFor, freesAgainst, dreamTeamPoints,
+rebound50s, goalAssists, goalAccuracy, ratingPoints, ranking, turnovers,
+intercepts, tacklesInside50, shotsAtGoal, goalEfficiency, shotEfficiency,
+interchangeCounts, scoreInvolvements, metresGained` — all `num` (some NA-only:
+`superGoals, ranking, goalEfficiency, shotEfficiency, interchangeCounts`).
+Sample: `goals=2, disposals=8, hitouts=1, metresGained=153`. **All captured.**
+
+### Clearances (`playerStats.stats.clearances.*`)
+
+`centreClearances, stoppageClearances, totalClearances` (num). All captured.
+
+### Extended stats (`playerStats.stats.extendedStats.*`)
+
+`effectiveKicks, kickEfficiency, kickToHandballRatio, effectiveDisposals,
+marksOnLead, interceptMarks, contestedPossessionRate, hitoutsToAdvantage,
+hitoutWinPercentage, hitoutToAdvantageRate, groundBallGets, f50GroundBallGets,
+scoreLaunches, pressureActs, defHalfPressureActs, spoils, ruckContests,
+contestDefOneOnOnes, contestDefLosses, contestDefLossPercentage,
+contestOffOneOnOnes, contestOffWins, contestOffWinsPercentage,
+centreBounceAttendances, kickins, kickinsPlayon` (num). **All captured.**
+`.normalise_player_stats_columns()` zero-fills any of these the API omits in a
+given season.
+
+### Added by parser
+
+| Field | Type | Description | Sample |
+|-------|------|-------------|--------|
+| `teamStatus` | chr | `home`/`away` indicator → `team_status` | `home` |
+| `providerId` | chr | Match id → `match_id` (after join) | `CD_M20260140603` |
+
+Match context joined in from fixtures: `venue_name, round_number,
+home_team_name, away_team_name, utc_start_time`.
+
+**Status:** This endpoint is already **fully faithful** — every API field is
+captured; no fields were dropped, so no additive change was needed.
+
+**Feeds →** `get_afl_player_stats()` → **`player_stats-data`** release → `load_player_stats()`. Map: `PLAYER_STATS_COL_MAP` + `.normalise_player_stats_columns()` (`R/column_schema.R:464`).
+
+---
+
+## Endpoint: `fixturesAndResults/season/CD_S{season}014/round/CD_R{season}014{round}`  (CFS, token)
+
+**URL:** `AFL_CFS_API_BASE_URL + "fixturesAndResults/season/CD_S{season}014/round/CD_R{season}014{round}"` (round zero-padded)
+**Fetched by:** `get_round_games()` (`R/scraper.R:226`) and `get_season_games()` (`R/scraper.R:264`) — the CFS-side round enumerator used to list matches before scraping chains.
+
+**Nesting:** `{ seasonId, roundId, teamId(NULL), venueId(NULL), fixtures: data.frame (32 cols), byes: list }`
+
+`get_round_games()` returns the whole `fixtures` data.frame untouched (only
+filtering `status == "CONCLUDED"` when `concluded_only`, and adding `date` +
+`season`). So **all 32 fixture fields pass through** to the chain-join pipeline.
+
+| Field (raw) | Type | Description | Sample | Captured? |
+|-------------|------|-------------|--------|-----------|
+| `status` | chr | Match status | `CONCLUDED` | Yes (filter key) |
+| `matchId` | chr | Match id (join key to chains) | `CD_M20260140101` | Yes |
+| `utcStartTime` | chr | Start (UTC) | `2026-03-12T08:30:00.000+0000` | Yes (→ `date`) |
+| `homeTeamId` / `awayTeamId` | chr | Team provider ids | `CD_T30` / `CD_T120` | Yes |
+| `competitionId` | chr | Comp-season provider id | `CD_S2026014` | Yes |
+| `roundNumber` | int | Round number | `1` | Yes |
+| `roundId` | chr | Round provider id | `CD_R202601401` | Yes |
+| `venueLocalStartTime` | logi/chr | Local start (often NA) | `NA` | Yes |
+| `lastUpdated` | chr | Record update timestamp | `2026-06-17T08:21:44.015+0000` | Yes |
+| `providerMatchId` | chr | Champion-Data numeric match id | `183201296` | Yes |
+| `venue.name` | chr | Venue | `MCG` | Yes |
+| `venue.timeZone` | chr | Venue timezone | `Australia/Melbourne` | Yes |
+| `venue.venueId` | chr | Venue provider id | `CD_V40` | Yes |
+| `venue.abbreviation` | chr | Venue abbr | `MCG` | Yes |
+| `venue.location` | chr | City | `Melbourne` | Yes |
+| `venue.state` | chr | State | `VIC` | Yes |
+| `venue.landOwner` | chr | Traditional owner | `Wurundjeri` | Yes |
+| `homeTeam.{teamAbbr,teamName,teamNickname}` | chr | Home team identity | `CARL` | Yes |
+| `awayTeam.{teamAbbr,teamName,teamNickname}` | chr | Away team identity | `RICH` | Yes |
+| `homeTeamScore.{totalScore,goals,behinds,superGoals}` | int/logi | Home score breakdown | `75/10/15/NA` | Yes |
+| `awayTeamScore.{totalScore,goals,behinds,superGoals}` | int/logi | Away score breakdown | `71/9/17/NA` | Yes |
+| top-level `seasonId` / `roundId` | chr | Echo of requested season/round | `CD_S2026014` | Used |
+| top-level `teamId` / `venueId` | NULL | Query echo (always NULL for round query) | `NULL` | No — empty echo |
+| `byes` | list() | Empty for this query shape | `list()` | No — empty |
+
+**Feeds →** internal chain pipeline only (`get_match_chains()` joins these
+fixture columns onto chains). The processed chains go to torpdata **`chains-data`**
+(→ `load_chains()`) and **`pbp-data`** (→ `load_pbp()`). This endpoint is a
+CFS-side mirror of the public `matches` fixtures.
+
+---
+
+## Endpoint: `players`  (CFS, token)
+
+**URL:** `AFL_CFS_API_BASE_URL + "players"`
+**Fetched by:** `get_players(use_api = TRUE)` (`R/scraper.R:330`). Default path is `use_api = FALSE` (reads the `player_details` release locally); the API path is a fallback that fetches the **current-season** full player list.
+
+**Nesting:** `{ pageNumber, pageSize, totalPages, totalResults, players: data.frame (10 cols) }`
+
+| Field (raw) | Type | Description | Sample | Captured? |
+|-------------|------|-------------|--------|-----------|
+| `playerId` | chr | Player provider id | `CD_I1019038` | Yes |
+| `jumperNumber` | int | Jumper number | `5` | Yes |
+| `playerPosition` | chr | Listed position class | `KEY_FORWARD` | Yes |
+| `photoURL` | chr | Headshot URL | `https://...` | Yes |
+| `playerName.givenName` | chr | First name | `Aaron` | Yes |
+| `playerName.surname` | chr | Surname | `Cadman` | Yes |
+| `team.teamId` | chr | Team provider id | `CD_T1010` | Yes |
+| `team.teamAbbr` | chr | Team abbreviation | `GWS` | Yes |
+| `team.teamName` | chr | Team name | `GWS GIANTS` | Yes |
+| `team.teamNickname` | chr | Team nickname | `GIANTS` | Yes |
+| `pageNumber/pageSize/totalPages/totalResults` | int | Pagination | `totalResults=812` | No — transport meta |
+
+`get_players()` adds `season = get_afl_season()`. All player fields pass
+through; only used as a chain-join lookup.
+
+**Feeds →** internal only — `get_match_chains()` left-joins player name/position
+onto chains by `(playerId, season)`. The local (default) path reads from the
+`player_details-data` release instead.
+
+---
+
+## Endpoint: `matchPlays/{match_id}`  (SAPI, token)  — CHAINS / PBP
+
+**URL:** `AFL_SAPI_BASE_URL + "matchPlays/" + match_id`
+**Fetched by:** `get_game_chains()` (`R/scraper.R:379`), one call per match, via `get_many_game_chains()` / `get_match_chains()`.
+
+The core play-by-play source: each match is a list of possession **chains**,
+each chain a list of action **stats** (events) with on-ground `(x, y)`
+coordinates. The parser explodes chains → action rows, attaching chain-level and
+match-level context to every row.
+
+**Top-level nesting:** `{ matchId, filter{...}, venueWidth, venueLength, homeTeamId, awayTeamId, homeTeamDirectionQtr1, matchChains: data.frame }`
+
+### Match-level fields (attached to every action row)
+
+| Field (raw) | Type | Description (→ canonical) | Sample | Captured? |
+|-------------|------|----------------------------|--------|-----------|
+| `matchId` | chr | Match id → `match_id` | `CD_M20260140603` | Yes |
+| `venueWidth` | int | Ground width (m) → `venue_width` | `136` | Yes |
+| `venueLength` | int | Ground length (m) → `venue_length` | `155` | Yes |
+| `homeTeamDirectionQtr1` | chr | Home attacking direction in Q1 (`left`/`right`) → `home_team_direction_qtr1` | `right` | Yes |
+| `homeTeamId` | chr | Home team id (same id-space as chain `teamId`) → `home_team_id` | `CD_T160` | **Captured (this audit)** |
+| `awayTeamId` | chr | Away team id → `away_team_id` | `CD_T1010` | **Captured (this audit)** |
+| `filter` | list (NULL×4) | Query echo: teamId/period/outcome/playerId (all NULL) | `NULL` | No — empty NULL query-echo, intentionally skipped |
+
+### Chain-level fields (`matchChains` rows → attached per action)
+
+| Field (raw) | Type | Description (→ canonical) | Sample | Captured? |
+|-------------|------|----------------------------|--------|-----------|
+| `teamId` | chr | Chain-possessing team (defines coordinate frame) → `chain_team_id` | `CD_T160` | Yes |
+| `initialState` | chr | How the chain started → `initial_state` | `centreBounce` | Yes |
+| `finalState` | chr | How the chain ended → `final_state` | `turnover` | Yes |
+| `period` | int | Quarter → `period` | `1` | Yes |
+| `periodSeconds` | int | Chain start time in period → `chain_period_seconds` | `0` | **Captured (this audit)** |
+| `stats` | list&lt;df&gt; | Action rows (exploded — see below) | df | Yes (exploded) |
+| *(added)* `chain_number` | int | Sequential chain index within match | `1` | Yes |
+
+### Action-level fields (`matchChains.stats[[i]]` → one row each)
+
+| Field (raw) | Type | Description (→ canonical) | Sample | Captured? |
+|-------------|------|----------------------------|--------|-----------|
+| `displayOrder` | int | Event order within chain → `display_order` | `1` | Yes |
+| `description` | chr | Event type | `Centre Bounce` | Yes |
+| `periodSeconds` | int | Event time in period → `period_seconds` | `0` | Yes |
+| `playerId` | chr | Acting player → `player_id` | `CD_I…` (NA for bounce) | Yes |
+| `teamId` | chr | Acting team (NOT the coordinate-frame team) → `team_id` | `CD_T…` | Yes |
+| `disposal` | chr | Disposal type | `NA`/`kick`/`handball` | Yes |
+| `shotAtGoal` | logi | Whether the action was a shot | `NA`/`TRUE` | Yes |
+| `behindInfo` | logi | Behind-type info | `NA` | Yes |
+| `x` | int | On-ground x coordinate | `0` | Yes |
+| `y` | int | On-ground y coordinate | `0` | Yes |
+
+Note: the API renamed the action array `actions` → `stats` circa 2026; the
+parser supports both names.
+
+**Feeds →** `get_match_chains()` → daily pipeline → torpdata **`chains-data`**
+(raw chains → `load_chains()`) and, after `clean_pbp()` / EP-WP-xG enrichment,
+**`pbp-data`** (→ `load_pbp()`) and **`xg-data`** (→ `load_xg()`). Map:
+`CHAINS_COL_MAP` (`R/column_schema.R:302`). The chain `teamId` (→ `chain_team_id`)
+sets the attacking coordinate frame; the action `teamId` does not — see
+`fix_chain_coordinates_dt()` and issue #92.
+
+---
+
+## Endpoint → torp release → loader summary
+
+| Endpoint | Fetch fn | torpdata release | Loader |
+|----------|----------|------------------|--------|
+| `competitions`, `compseasons` | `.afl_all_comp_seasons()` | — (internal lookup) | — |
+| `matches` | `get_afl_fixtures()` | `fixtures-data` | `load_fixtures()` |
+| `matches` (CONCLUDED) | `get_afl_results()` | `results-data` | `load_results()` |
+| `squads` | `get_afl_player_details()` | `player_details-data` | `load_player_details()` |
+| `matchRoster/full` | `get_afl_lineups()` | `teams-data` | `load_teams()` |
+| `playerStats/match` | `get_afl_player_stats()` | `player_stats-data` | `load_player_stats()` |
+| `fixturesAndResults/...round...` | `get_round_games()` / `get_season_games()` | (chain enumerator) | — |
+| `players` | `get_players(use_api=TRUE)` | (chain join, fallback) | — |
+| `matchPlays` | `get_match_chains()` | `chains-data`, `pbp-data`, `xg-data` | `load_chains()`, `load_pbp()`, `load_xg()` |
+
+*Live-verification:* every endpoint above was reached live on 2026-06-18.
+None were documented purely from code/cache.

--- a/AFL-API-REFERENCE.md
+++ b/AFL-API-REFERENCE.md
@@ -467,9 +467,11 @@ match-level context to every row.
 | `venueWidth` | int | Ground width (m) → `venue_width` | `136` | Yes |
 | `venueLength` | int | Ground length (m) → `venue_length` | `155` | Yes |
 | `homeTeamDirectionQtr1` | chr | Home attacking direction in Q1 (`left`/`right`) → `home_team_direction_qtr1` | `right` | Yes |
-| `homeTeamId` | chr | Home team id (same id-space as chain `teamId`) → `home_team_id` | `CD_T160` | **Captured (this audit)** |
-| `awayTeamId` | chr | Away team id → `away_team_id` | `CD_T1010` | **Captured (this audit)** |
+| `homeTeamId` | chr | Home team id (same id-space as chain `teamId`) → captured as `mp_home_team_id` | `CD_T160` | **Captured (this audit)** |
+| `awayTeamId` | chr | Away team id → captured as `mp_away_team_id` | `CD_T1010` | **Captured (this audit)** |
 | `filter` | list (NULL×4) | Query echo: teamId/period/outcome/playerId (all NULL) | `NULL` | No — empty NULL query-echo, intentionally skipped |
+
+> **Naming note:** captured under the `mp_` (matchPlays) prefix, NOT bare `homeTeamId` — `get_match_chains` joins `homeTeamId` in from the games/fixtures data (`inner_join(games, by="matchId")`), so a bare capture collides and suffixes both to `home_team_id_x`/`_y`, breaking `home_team_id` resolution. `mp_home_team_id`/`mp_away_team_id` stay distinct; `clean_pbp` prefers them for coordinate orientation (#92).
 
 ### Chain-level fields (`matchChains` rows → attached per action)
 

--- a/AFL-API-REFERENCE.md
+++ b/AFL-API-REFERENCE.md
@@ -472,6 +472,8 @@ match-level context to every row.
 | `filter` | list (NULL×4) | Query echo: teamId/period/outcome/playerId (all NULL) | `NULL` | No — empty NULL query-echo, intentionally skipped |
 
 > **Naming note:** captured under the `mp_` (matchPlays) prefix, NOT bare `homeTeamId` — `get_match_chains` joins `homeTeamId` in from the games/fixtures data (`inner_join(games, by="matchId")`), so a bare capture collides and suffixes both to `home_team_id_x`/`_y`, breaking `home_team_id` resolution. `mp_home_team_id`/`mp_away_team_id` stay distinct; `clean_pbp` prefers them for coordinate orientation (#92).
+>
+> **Completeness guarantee:** `get_game_chains` captures fields at all three levels *generically*, not by allow-list: action-level via `as.data.table(stats)`, and **every** other chain-level scalar field (prefixed `chain_`) and match-level scalar field (prefixed `mp_`). The known fields above keep fixed names for the pipeline; anything an older/future schema adds is archived automatically. So `chains-data` is a complete archive of every matchPlays scalar column — a missing column never forces a re-scrape; only a genuine API *schema change* does. (The exploded `matchChains`/`stats` arrays and the empty `filter` echo are the only exclusions.)
 
 ### Chain-level fields (`matchChains` rows → attached per action)
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -145,20 +145,17 @@ The AFL API delivers `x,y` in a **possession-team-relative** frame: positive x =
 
 `fix_chain_coordinates_dt()` converts to **pitch-relative** (`x_pitch`, `y_pitch`) -- a fixed home-team frame where the same physical location always has the same coordinates regardless of possession. This makes consecutive rows spatially comparable for EP/WP modeling.
 
-The AFL API frequently delivers coordinates in the **wrong team's frame** at possession changes (~12% of non-throw-in rows), producing sign-flipped x,y values. The fix pipeline in `clean_pbp.R` corrects this in 8 steps:
+**Orientation at the source (issue #92).** The AFL API records coordinates in the **possessing chain's attacking frame** (`matchChains[i].teamId`), not the acting player's team. The old pipeline oriented off the actor, mis-flipping ~7% of shots (and ~12% of possession-change rows). The fix captures `chain_team_id` + `mp_home_team_id` in the scraper and orients **step A** off the chain frame (`coord_team_id` vs `coord_home_team_id`). With orientation correct at the source, the former neighbour-cascade sign-flip net (old steps D/E/F) modifies **zero rows** (verified by ablation over two full seasons) and has been **removed** — it was a symptom treatment for jumps the orientation bug itself generated. The remaining pipeline:
 
 | Step | Fix | What it catches |
 |------|-----|-----------------|
-| A | Convert to pitch-relative (`as.double`) | Frame alignment + avoids integer truncation |
+| A | Convert to pitch-relative off `coord_team_id`/`coord_home_team_id` (`as.double`) | Frame alignment from the chain's attacking frame (**the #92 fix**) |
 | B | Throw-in fix (2 passes) | Centre Bounce, OOB, Ball Up rows → use next row's position |
-| C | Iterative sign-flip (`COORD_FLIP_TOLERANCE`) | Single and cascading wrong-frame rows. Flips when jump >100m but negating puts within 70m of predecessor |
-| D | Both-neighbor sign-flip (60m tolerance) | Longer-distance sign-flips confirmed by both neighbors |
-| E | Neighbor interpolation | Remaining outliers far from both neighbors |
-| F | Paired sign-flip | Two consecutive wrong rows (e.g. Spoil + Kickin) |
+| C | Single conservative prev-based flip (shot-protected) | The few genuinely ambiguous stoppage/possession-boundary rows (~10/season); `shot_at_goal` rows are never flipped |
 | G | Convert back to team-relative | Restores `x,y` to possession-team frame |
 | H | Recalculate `goal_x` | `venue_length / 2 - x` |
 
-Constants in `R/constants_data.R`: `COORD_JUMP_THRESHOLD` (100m) gates all sign-flip checks. `COORD_FLIP_TOLERANCE` (70m) is the max flipped distance to classify as a sign error -- set to cover the longest realistic kick distances. Together they eliminate ~99.7% of >100m pitch-relative jumps.
+Constants in `R/constants_data.R`: `COORD_JUMP_THRESHOLD` (100m) gates the step-C flip check; `COORD_FLIP_TOLERANCE` (70m) is the max flipped distance to classify as a sign error. Post-#92 the jump-detection is near-inert — coordinate correctness is delivered by step A's orientation, not by the cascade.
 
 **Column Schema** (`column_schema.R`):
 - 11 COL_MAP constants (named character vectors) for each data type: `PLAYER_STATS_COL_MAP`, `PBP_COL_MAP`, `FIXTURE_COL_MAP`, `TEAMS_COL_MAP`, `CHAINS_COL_MAP`, `PLAYER_GAME_COL_MAP`, `TORP_RATINGS_COL_MAP`, `PLAYER_GAME_RATINGS_COL_MAP`, `PLAYER_DETAILS_COL_MAP`, `PREDICTIONS_COL_MAP`, `XG_COL_MAP`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,7 @@ Live EP/WP/xG models are trained in **torpmodels** (`data-raw/01-ep-model/train_
 - **Shot distance bug** — `shots.parquet` computes distance with signed x (`halfLen - x`) instead of `halfLen - |x|`, so negative-x shots show distance to the *far* goal. inthegame-blog overrides client-side; fix in torp would let the override become a no-op.
 - **Team name canonicalisation** — `save_to_release()` calls `.normalise_team_values()` before write; outside that path you may see raw API names (Footscray, GWS) vs full names (Western Bulldogs, GWS Giants). Use `AFL_TEAM_ALIASES` to translate.
 - **Off-season `run_daily_release()` returns FALSE** — by design, so the GHA workflow can skip release/dispatch steps. Don't treat FALSE as an error.
+- **`load_*()` loaders default to the *current* season** — `load_player_stat_ratings()`, `load_player_stats()`, etc. default `seasons = get_afl_season()`, and `seasons = TRUE` means *all* seasons (`AFL_MIN_SEASON:current`). But `torp_ratings.parquet` (`ratings-data`) is **full-history** — it's upserted into the existing release each run. So any pipeline stage that blends per-round data into the full table must pass `TRUE`, or historical rows silently fall back to a current-season snapshot. This was the #88 PSR/OSR/DSR "flat across history" bug: `run_ratings_pipeline.R` fed `calculate_torp()` a current-season-only PSR frame.
 
 ## Tests
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ powershell.exe -Command 'Rscript "path/to/script.R"'
 | Domain | Key files | Purpose |
 |--------|-----------|---------|
 | **Data loading** | `load_data.R`, `load_utils.R`, `load_engines.R`, `local_data.R` | `load_*()` family (load_pbp, load_results, load_torp_ratings, ...) — fetch from GitHub Releases or `get_local_data_dir()` |
-| **Scraping** | `afl_api.R`, `scraper.R`, `injuries_scrape.R` | In-house AFL API (replaced fitzRoy), injury scraping |
+| **Scraping** | `afl_api.R`, `scraper.R`, `injuries_scrape.R` | In-house AFL API (replaced fitzRoy), injury scraping — see [`AFL-API-REFERENCE.md`](AFL-API-REFERENCE.md) for the full endpoint/field dictionary |
 | **EP / WP / xG** | `add_variables.R`, `win_probability.R`, `wp_credit.R`, `wp_utils.R`, `xg.R` | `add_epv_vars()`, `add_wp_vars()`, `add_shot_vars()` — feature engineering and credit assignment |
 | **TORP / EPR / PSR** | `player_ratings.R`, `player_skills.R`, `psr.R`, `player_credit.R`, `player_attribution.R` | Core rating composition. `TORP_EPR_WEIGHT = 0.5` blends EPV+PSV; WPA tracked separately |
 | **Per-game ratings** | `player_game_ratings.R`, `player_skills_data.R`, `player_skills_profile.R` | `get_player_game_ratings()` returns EPV+WPA+PSV per game |

--- a/R/afl_api.R
+++ b/R/afl_api.R
@@ -418,6 +418,14 @@ NULL
     players$teamName <- team_name
     players$teamType <- team_type
     players$providerId <- match_id
+
+    # Bring through team-level lineup status (e.g. "FINAL_TEAM") for posterity
+    # (issue #92 API audit). Distinguishes confirmed final lineups from
+    # provisional/extended squads. Other matchRoster fields (weather, umpires,
+    # ins/outs, milestones, recentMatches) are match-level, not player-grained,
+    # so they belong in the chains/results tables, not this roster table.
+    players$teamStatus <- as.character(team_data$teamStatus)[1] %||% NA_character_
+
     players
   }
 
@@ -488,6 +496,19 @@ NULL
 
   players$team.name <- json$squad$team$name %||% NA_character_
   players$team.providerId <- json$squad$team$providerId %||% NA_character_
+
+  # Bring through additional team-identity fields from squad$team for posterity
+  # (issue #92 API audit). team.id is the numeric team id (same id-space as the
+  # public matches endpoint's home/away.team.id); abbreviation/nickname/teamType
+  # round out the team identity. squad$team$club.* and squad$team$metadata.*
+  # (social media URLs, captainIds) are intentionally NOT captured — club is
+  # redundant with team for AFL and metadata is non-analytical noise. squad$
+  # compSeason is intentionally skipped — fully redundant with the `season`
+  # column derived downstream.
+  players$team.id <- json$squad$team$id %||% NA_integer_
+  players$team.abbreviation <- json$squad$team$abbreviation %||% NA_character_
+  players$team.nickname <- json$squad$team$nickname %||% NA_character_
+  players$team.teamType <- json$squad$team$teamType %||% NA_character_
 
   # Drop list-columns
   players <- .drop_list_cols(players)
@@ -603,6 +624,23 @@ get_afl_fixtures <- function(season = NULL) {
 
   matches <- json$matches
   if (is.null(matches) || length(matches) == 0) return(NULL)
+
+  # Capture round.byes (a list-column of per-match data.frames of teams on the
+  # bye that round) as a flat comma-separated abbreviation string before it is
+  # dropped by .drop_list_cols(). Faithfully archives which teams had a bye for
+  # each fixture's round (issue #92 API audit). Empty/absent byes -> NA.
+  if ("round.byes" %in% names(matches)) {
+    matches$round_byes <- vapply(matches$round.byes, function(b) {
+      if (is.null(b) || length(b) == 0) return(NA_character_)
+      if (is.data.frame(b)) {
+        col <- intersect(c("abbreviation", "name", "providerId"), names(b))[1]
+        if (is.na(col) || nrow(b) == 0) return(NA_character_)
+        paste(b[[col]], collapse = ", ")
+      } else {
+        paste(unlist(b), collapse = ", ")
+      }
+    }, character(1))
+  }
 
   # Drop list-columns (nested structs) that arrow can't serialize
   matches <- .drop_list_cols(matches)

--- a/R/clean_features.R
+++ b/R/clean_features.R
@@ -35,7 +35,7 @@ clean_model_data_epv_dt <- function(df) {
   dt <- dt[lag_ti_flt == 0L | lead_ti_flt == 0L | throw_in == 0L]
   dt[, c("lag_ti_flt", "lead_ti_flt") := NULL]
 
-  # Team vars, mirror, coordinate transform
+  # Team vars (mirror neutralised post-#92 — see add_epv_team_vars_dt)
   add_epv_team_vars_dt(dt, grp)
 
   # Lagged variables + speed
@@ -48,9 +48,10 @@ clean_model_data_epv_dt <- function(df) {
 
 #' Add EPV team variables (data.table, by reference)
 #'
-#' Computes team_id_mdl, home, points, mirror, and coordinate transform.
-#' All shift operations for the mirror calculation are batched into a single
-#' := call for performance.
+#' Computes team_id_mdl, home, and points. The legacy `mirror` coordinate
+#' flip is neutralised post-#92 (set to constant 1) — clean_pbp now leaves
+#' coordinates in the correct action-team attacking frame, so the second
+#' normalisation here double-corrected. See the inline note for the ablation.
 #'
 #' @param dt A data.table to modify by reference.
 #' @param grp Character vector of grouping columns.
@@ -73,67 +74,26 @@ add_epv_team_vars_dt <- function(dt, grp) {
   )]
   dt[, points_diff := pos_points - opp_points]
 
-  # Batch all 11 shifts needed for mirror (single pass over group index)
-  dt[, c("tmp_lag1_ti", "tmp_lag2_ti",
-         "tmp_lag1_tm", "tmp_lag2_tm", "tmp_lag3_tm",
-         "tmp_lag1_x", "tmp_lag2_x",
-         "tmp_lead1_x", "tmp_lead2_x",
-         "tmp_lead1_tm", "tmp_lead2_tm") := .(
-    data.table::shift(throw_in, 1L, type = "lag"),
-    data.table::shift(throw_in, 2L, type = "lag"),
-    data.table::shift(team_id_mdl, 1L, type = "lag"),
-    data.table::shift(team_id_mdl, 2L, type = "lag"),
-    data.table::shift(team_id_mdl, 3L, type = "lag"),
-    data.table::shift(x, 1L, type = "lag"),
-    data.table::shift(x, 2L, type = "lag"),
-    data.table::shift(x, 1L, type = "lead"),
-    data.table::shift(x, 2L, type = "lead"),
-    data.table::shift(team_id_mdl, 1L, type = "lead"),
-    data.table::shift(team_id_mdl, 2L, type = "lead")
-  ), by = grp]
-
-  # Pre-compute sign() values to avoid repeated evaluation over 1.6M rows.
-  # sign(x) is used in 6 of the 7 conditions; sign(tmp_lag1_x) in 3.
-  dt[, c("s_x", "s_lag1_x", "s_lag2_x", "s_lead1_x", "s_lead2_x") := .(
-    sign(x), sign(tmp_lag1_x), sign(tmp_lag2_x), sign(tmp_lead1_x), sign(tmp_lead2_x)
-  )]
-
-  # Mirror via fcase (same 7 conditions as the original dplyr calculate_mirror,
-  # NAs treated as FALSE)
-  dt[, mirror := data.table::fcase(
-    # 1. Current throw-in with team change
-    throw_in == 1L & tmp_lag1_ti != 1L & tmp_lag1_tm != team_id_mdl, -1,
-    # 2. Consecutive throw-ins on same side with different team
-    throw_in == 1L & tmp_lag1_ti == 1L & tmp_lag2_tm != team_id_mdl &
-      s_lag1_x == s_x, -1,
-    # 3. Consecutive throw-ins with same team but different side
-    throw_in == 1L & tmp_lag1_ti == 1L & tmp_lag2_tm == team_id_mdl &
-      s_lag1_x != s_x, -1,
-    # 4. Previous throw-in affecting current play
-    tmp_lag1_ti == 1L & s_lag1_x == s_x &
-      tmp_lag1_tm == team_id_mdl & tmp_lag2_tm != team_id_mdl, -1,
-    # 5. Throw-in two plays ago affecting current play
-    tmp_lag2_ti == 1L & s_lag2_x == s_x &
-      tmp_lag2_tm == team_id_mdl & tmp_lag3_tm != team_id_mdl, -1,
-    # 6. Previous throw-in with future position considerations
-    tmp_lag1_ti == 1L & s_lead2_x == s_x &
-      tmp_lead2_tm != team_id_mdl, -1,
-    # 7. Two plays ago throw-in with future considerations
-    tmp_lag2_ti == 1L & s_lead1_x == s_x &
-      tmp_lead1_tm != team_id_mdl, -1,
-    default = 1
-  )]
-
-  # Clean up mirror temp columns
-  dt[, c("tmp_lag1_ti", "tmp_lag2_ti",
-         "tmp_lag1_tm", "tmp_lag2_tm", "tmp_lag3_tm",
-         "tmp_lag1_x", "tmp_lag2_x",
-         "tmp_lead1_x", "tmp_lead2_x",
-         "tmp_lead1_tm", "tmp_lead2_tm",
-         "s_x", "s_lag1_x", "s_lag2_x", "s_lead1_x", "s_lead2_x") := NULL]
-
-  # Apply coordinate transform (x, y must be updated before goal_x)
-  dt[, `:=`(x = mirror * x, y = mirror * y)]
+  # --- Mirror neutralised (issue #92 sweep) ---
+  # The `mirror` was a SECOND frame-normalisation heuristic: 7 throw-in-based
+  # fcase conditions keyed on sign(x) vs neighbouring throw-ins that flipped a
+  # row's (x, y) to renormalise it into the EP-model attacking frame. It was
+  # built for the PRE-#92 era when clean_pbp's coordinates were unreliable.
+  #
+  # Post-#92, clean_pbp already leaves every row in the action-team (team_id_mdl)
+  # attacking frame: step A orients off the captured chain frame
+  # (coord_team_id / coord_home_team_id) and step B fixes throw-in/stoppage rows
+  # to where play resumes. So this mirror now double-corrects what clean_pbp has
+  # already handled — exactly like the clean_pbp neighbour-cascade (former steps
+  # D/E/F) we removed. An ablation over post-#92 2021 data showed the flip fires
+  # on ~17k rows yet HARMS ~99.5% of those that have a same-team predecessor
+  # (median jump 0m -> 103m away from the same-team neighbour) while helping a
+  # handful, and flips ~67 already-correct shots (x>0 -> x<0), reintroducing the
+  # residual ~0.7% mis-orientation. It corrects zero shots. Neutralised to the
+  # identity. `mirror` is retained as a constant 1 column for downstream
+  # compatibility. If a future API schema reintroduces frame errors, restore the
+  # 7-condition heuristic from git history and re-measure. See issue #92.
+  dt[, mirror := 1]
   dt[, goal_x := venue_length / 2 - x]
 
   invisible(NULL)

--- a/R/clean_pbp.R
+++ b/R/clean_pbp.R
@@ -249,11 +249,12 @@ fix_chain_coordinates_dt <- function(dt) {
       dist_as_is > COORD_JUMP_THRESHOLD &
       dist_flipped < COORD_FLIP_TOLERANCE &
       !is.na(prev_x) &
-      # Never flip a shot_at_goal row. Post-#92 its coordinates are already
-      # correctly oriented (step A), and a shot is a reliable anchor near the
-      # attacking goal — flipping it to match a noisy neighbour from an adjacent
-      # chain was the residual ~0.7% mis-orientation. Shots can still anchor the
-      # flip of OTHER rows; they just can't be the flipped row. See issue #92.
+      # Never flip a shot_at_goal row — a shot is a reliable anchor near the
+      # attacking goal and shouldn't be repositioned by a noisy neighbour.
+      # Defensive only: post-#92 step C rarely fires on shots. (The ~0.7%
+      # residual mis-orientation found in the Stage-1 backfill turned out to be
+      # the EPV `mirror` transform in clean_features.R, since neutralised — NOT
+      # this cascade.) Shots can still anchor the flip of other rows. See #92.
       shot_row != 1L
     )]
     n_flipped <- length(flip_rows)

--- a/R/clean_pbp.R
+++ b/R/clean_pbp.R
@@ -137,17 +137,17 @@ add_team_id_mdl_dt <- function(dt) {
   }
 
   # coord_home_team_id: the home-end reference for coordinate orientation. The
-  # AFL API's matchPlays response carries homeTeamId in the SAME id-space as
-  # chain_team_id, so when the scraper captured it, prefer it — making the
-  # orientation comparison (coord_team_id vs home end) fully self-contained from
-  # the response that defines (x, y), rather than depending on the home_team_id
-  # joined in from results-data. Falls back to the joined home_team_id for legacy
-  # parquets / missing values. A no-op whenever the two agree (every correctly-
-  # sourced match), so it only ever corrects a results/chains home-away mismatch.
-  # See issue #92 (API field audit).
-  if ("homeTeamId" %in% names(dt)) {
+  # AFL API's matchPlays response carries the home team id (captured as
+  # mp_home_team_id) in the SAME id-space as chain_team_id, so when the scraper
+  # captured it, prefer it — making the orientation comparison (coord_team_id vs
+  # home end) fully self-contained from the response that defines (x, y), rather
+  # than depending on the home_team_id joined in from the games/results data.
+  # Falls back to the joined home_team_id for legacy parquets / missing values.
+  # A no-op whenever the two agree (every correctly-sourced match), so it only
+  # ever corrects a games/chains home-away mismatch. See issue #92 (API audit).
+  if ("mp_home_team_id" %in% names(dt)) {
     dt[, coord_home_team_id := data.table::fifelse(
-      is.na(homeTeamId), home_team_id, homeTeamId
+      is.na(mp_home_team_id), home_team_id, mp_home_team_id
     )]
   } else {
     dt[, coord_home_team_id := home_team_id]

--- a/R/clean_pbp.R
+++ b/R/clean_pbp.R
@@ -168,9 +168,11 @@ add_team_id_mdl_dt <- function(dt) {
 #' Step A now orients to the pitch using `coord_team_id` (the captured
 #' chain-level team), so opponent-actor rows and the trailing event of the
 #' previous chain land in a consistent frame and no longer present as ~90m
-#' jumps that the steps C-F neighbour cascade would mis-flip. The C-F steps are
-#' retained as a defensive net for residual API noise but should rarely fire on
-#' correctly-oriented data.
+#' jumps. The old neighbour-cascade sign-flip net (former steps D/E/F) was a
+#' symptom treatment for the pre-fix orientation bug; with orientation correct
+#' it modifies zero rows (verified by ablation over two full seasons) and has
+#' been removed. Step B (throw-in fix) and step C (a single conservative
+#' prev-based flip catch, with shot rows protected) remain.
 #'
 #' Backward compatibility: parquets scraped before `chain_team_id` was captured
 #' fall back to `team_id_mdl` for orientation, reproducing the prior (buggy)
@@ -246,7 +248,13 @@ fix_chain_coordinates_dt <- function(dt) {
     flip_rows <- dt[, which(
       dist_as_is > COORD_JUMP_THRESHOLD &
       dist_flipped < COORD_FLIP_TOLERANCE &
-      !is.na(prev_x)
+      !is.na(prev_x) &
+      # Never flip a shot_at_goal row. Post-#92 its coordinates are already
+      # correctly oriented (step A), and a shot is a reliable anchor near the
+      # attacking goal — flipping it to match a noisy neighbour from an adjacent
+      # chain was the residual ~0.7% mis-orientation. Shots can still anchor the
+      # flip of OTHER rows; they just can't be the flipped row. See issue #92.
+      shot_row != 1L
     )]
     n_flipped <- length(flip_rows)
 
@@ -261,99 +269,17 @@ fix_chain_coordinates_dt <- function(dt) {
             ") with ", n_flipped, " rows still flagged. Possible oscillating coordinates.")
   }
 
-  # --- D) Both-neighbor sign-flip (looser tolerance) ---
-  # Catches sign-flips missed by step C due to longer kick distances.
-  # Safe to use looser tolerance because both neighbors must confirm the flip.
-  dt[, `:=`(
-    prev_x = data.table::shift(x_pitch, 1L, type = "lag"),
-    prev_y = data.table::shift(y_pitch, 1L, type = "lag"),
-    next_x = data.table::shift(x_pitch, 1L, type = "lead"),
-    next_y = data.table::shift(y_pitch, 1L, type = "lead")
-  ), by = .(match_id, period)]
-
-  dt[!is.na(prev_x) & !is.na(next_x), `:=`(
-    jump_dist = sqrt((x_pitch - prev_x)^2 + (y_pitch - prev_y)^2),
-    flip_prev = sqrt((-x_pitch - prev_x)^2 + (-y_pitch - prev_y)^2),
-    flip_next = sqrt((-x_pitch - next_x)^2 + (-y_pitch - next_y)^2),
-    total_asis = sqrt((x_pitch - prev_x)^2 + (y_pitch - prev_y)^2) +
-                 sqrt((x_pitch - next_x)^2 + (y_pitch - next_y)^2),
-    total_flip = sqrt((-x_pitch - prev_x)^2 + (-y_pitch - prev_y)^2) +
-                 sqrt((-x_pitch - next_x)^2 + (-y_pitch - next_y)^2)
-  )]
-
-  dt[jump_dist > COORD_JUMP_THRESHOLD &
-     flip_prev < 60 & flip_next < 60 &
-     total_flip < total_asis &
-     !is.na(prev_x) & !is.na(next_x), `:=`(
-    x_pitch = -x_pitch,
-    y_pitch = -y_pitch
-  )]
-
-  dt[, c("flip_prev", "flip_next", "total_asis", "total_flip") := NULL]
-
-  # --- E) Smooth remaining outliers via neighbor interpolation ---
-  # Recompute neighbors fresh (step D may have flipped some rows)
-  dt[, c("prev_x", "prev_y", "next_x", "next_y") := NULL]
-  dt[, `:=`(
-    prev_x = data.table::shift(x_pitch, 1L, type = "lag"),
-    prev_y = data.table::shift(y_pitch, 1L, type = "lag"),
-    next_x = data.table::shift(x_pitch, 1L, type = "lead"),
-    next_y = data.table::shift(y_pitch, 1L, type = "lead")
-  ), by = .(match_id, period)]
-
-  dt[!is.na(prev_x) & !is.na(next_x), `:=`(
-    jump_dist = sqrt((x_pitch - prev_x)^2 + (y_pitch - prev_y)^2),
-    next_jump = sqrt((next_x - x_pitch)^2 + (next_y - y_pitch)^2)
-  )]
-
-  dt[jump_dist > COORD_JUMP_THRESHOLD & next_jump > COORD_JUMP_THRESHOLD &
-     !is.na(prev_x) & !is.na(next_x), `:=`(
-    x_pitch = (prev_x + next_x) / 2,
-    y_pitch = (prev_y + next_y) / 2
-  )]
-
-  dt[, c("prev_x", "prev_y", "next_x", "next_y",
-         "jump_dist", "next_jump") := NULL]
-
-  # --- F) Paired sign-flip fix ---
-  # Catches cases where TWO consecutive rows are both sign-flipped (e.g.
-  # Out On Full + OOF Kick In, or Spoil + Kickin). Flipping the pair together
-  # improves the jump from the predecessor without hurting the successor.
-  # The !is.na(next2_x) guard (shift with by=match_id,period) ensures
-  # pair_rows + 1 never crosses a match/period boundary.
-  dt[, `:=`(
-    prev_x = data.table::shift(x_pitch, 1L, type = "lag"),
-    prev_y = data.table::shift(y_pitch, 1L, type = "lag"),
-    next_x = data.table::shift(x_pitch, 1L, type = "lead"),
-    next_y = data.table::shift(y_pitch, 1L, type = "lead"),
-    next2_x = data.table::shift(x_pitch, 2L, type = "lead"),
-    next2_y = data.table::shift(y_pitch, 2L, type = "lead")
-  ), by = .(match_id, period)]
-
-  dt[!is.na(prev_x) & !is.na(next2_x), `:=`(
-    jump_dist = sqrt((x_pitch - prev_x)^2 + (y_pitch - prev_y)^2),
-    flip_prev = sqrt((-x_pitch - prev_x)^2 + (-y_pitch - prev_y)^2),
-    flip_pair_to_next2 = sqrt((-next_x - next2_x)^2 + (-next_y - next2_y)^2)
-  )]
-
-  pair_rows <- dt[, which(
-    jump_dist > COORD_JUMP_THRESHOLD &
-    flip_prev < 60 &
-    flip_pair_to_next2 < 60 &
-    !is.na(prev_x) & !is.na(next2_x)
-  )]
-
-  if (length(pair_rows) > 0L) {
-    dt[pair_rows, `:=`(x_pitch = -x_pitch, y_pitch = -y_pitch)]
-    next_rows <- pair_rows + 1L
-    next_rows <- next_rows[next_rows <= nrow(dt)]
-    if (length(next_rows) > 0L) {
-      dt[next_rows, `:=`(x_pitch = -x_pitch, y_pitch = -y_pitch)]
-    }
-  }
-
-  dt[, c("prev_x", "prev_y", "next_x", "next_y", "next2_x", "next2_y",
-         "jump_dist", "flip_prev", "flip_pair_to_next2") := NULL]
+  # --- (former steps D/E/F removed — issue #92 sweep) ---
+  # The both-neighbour flip (D), outlier interpolation (E), and paired flip (F)
+  # were a sign-flip defensive net for the PRE-#92 orientation bug, which
+  # *generated* the >100m jumps they "fixed". With coordinates now oriented
+  # correctly off the chain frame in step A (coord_team_id / coord_home_team_id),
+  # an ablation over two full seasons (2021, 2024) showed D/E/F modify ZERO rows
+  # — disabling them is byte-identical to running them — while still carrying the
+  # false-flip risk that mis-oriented ~0.7% of shots. Removed. Step B (throw-in
+  # fix) and step C (single conservative prev-based flip catch, shot-protected)
+  # remain. If a future API schema reintroduces frame errors, restore from git
+  # history and re-measure. See issue #92.
 
   # --- G) Convert back to action-team perspective ---
   # IMPORTANT: step A oriented to pitch using coord_team_id (chain frame), but

--- a/R/clean_pbp.R
+++ b/R/clean_pbp.R
@@ -136,6 +136,23 @@ add_team_id_mdl_dt <- function(dt) {
     dt[, coord_team_id := team_id_mdl]
   }
 
+  # coord_home_team_id: the home-end reference for coordinate orientation. The
+  # AFL API's matchPlays response carries homeTeamId in the SAME id-space as
+  # chain_team_id, so when the scraper captured it, prefer it — making the
+  # orientation comparison (coord_team_id vs home end) fully self-contained from
+  # the response that defines (x, y), rather than depending on the home_team_id
+  # joined in from results-data. Falls back to the joined home_team_id for legacy
+  # parquets / missing values. A no-op whenever the two agree (every correctly-
+  # sourced match), so it only ever corrects a results/chains home-away mismatch.
+  # See issue #92 (API field audit).
+  if ("homeTeamId" %in% names(dt)) {
+    dt[, coord_home_team_id := data.table::fifelse(
+      is.na(homeTeamId), home_team_id, homeTeamId
+    )]
+  } else {
+    dt[, coord_home_team_id := home_team_id]
+  }
+
   invisible(NULL)
 }
 
@@ -183,8 +200,8 @@ fix_chain_coordinates_dt <- function(dt) {
   # the steps C-F cascade would mis-flip. See issue #92.
   # Use as.double() to avoid integer truncation when interpolating later
   dt[, `:=`(
-    x_pitch = as.double(data.table::fifelse(coord_team_id == home_team_id, x, -x)),
-    y_pitch = as.double(data.table::fifelse(coord_team_id == home_team_id, y, -y))
+    x_pitch = as.double(data.table::fifelse(coord_team_id == coord_home_team_id, x, -x)),
+    y_pitch = as.double(data.table::fifelse(coord_team_id == coord_home_team_id, y, -y))
   )]
 
   # --- B) Fix throw-in/stoppage rows ---
@@ -348,8 +365,8 @@ fix_chain_coordinates_dt <- function(dt) {
   # identity; only genuine opponent-actor rows are intentionally negated here.
   # See issue #92.
   dt[, `:=`(
-    x = as.integer(round(data.table::fifelse(team_id_mdl == home_team_id, x_pitch, -x_pitch))),
-    y = as.integer(round(data.table::fifelse(team_id_mdl == home_team_id, y_pitch, -y_pitch)))
+    x = as.integer(round(data.table::fifelse(team_id_mdl == coord_home_team_id, x_pitch, -x_pitch))),
+    y = as.integer(round(data.table::fifelse(team_id_mdl == coord_home_team_id, y_pitch, -y_pitch)))
   )]
 
   dt[, c("x_pitch", "y_pitch") := NULL]

--- a/R/scraper.R
+++ b/R/scraper.R
@@ -393,6 +393,18 @@ get_game_chains <- function(match_id) {
   # API renamed "actions" → "stats" circa 2026; support both
   actions_col <- which(names(chain_list) %in% c("stats", "actions"))
   col_idx <- if (length(actions_col) == 1) actions_col else 6
+  stats_col_name <- names(chain_list)[col_idx]
+
+  # Chain-level fields captured below under fixed names that the downstream
+  # pipeline depends on. EVERYTHING else the matchPlays response exposes at chain
+  # level — including any field an older or future API schema adds — is captured
+  # generically with a `chain_` prefix, so the chains archive is complete and a
+  # missing column never forces a re-scrape (issue #92 API audit). teamId and
+  # periodSeconds get fixed renames because they collide with the action-level
+  # columns of the same name.
+  known_chain <- c("teamId", "periodSeconds", "initialState", "finalState",
+                   "period", stats_col_name)
+  extra_chain <- setdiff(names(chain_list), known_chain)
 
   chains <- data.table::rbindlist(lapply(seq_len(nrow(chain_list)), function(i) {
     acts <- chain_list[[i, col_idx]]
@@ -403,38 +415,51 @@ get_game_chains <- function(match_id) {
       initialState = chain_list$initialState[i],
       period = chain_list$period[i],
       chain_number = i,
-      # Chain-level possessing team (matchChains[i].teamId). This defines the
+      # Chain-level possessing team (matchChains[i].teamId): defines the
       # attacking coordinate frame for EVERY action row in the chain. The
-      # action-level stats[j].teamId only says who performed the event (e.g. a
-      # spoil/contest by the opponent), so it must NOT be used to decide
-      # coordinate orientation. See fix_chain_coordinates_dt() and issue #92.
+      # action-level stats[j].teamId only says who performed the event, so it
+      # must NOT decide coordinate orientation. See fix_chain_coordinates_dt(),
+      # issue #92. (renamed from teamId — collides with the action-level teamId.)
       chain_team_id = chain_list$teamId[i],
-      # Chain-level timestamp (seconds into the period). Distinct from the
-      # action-level periodSeconds already on each stats row; named to avoid
-      # collision. Captured for posterity (issue #92 API audit).
+      # Chain-level timestamp; renamed from periodSeconds (action rows already
+      # carry their own periodSeconds).
       chain_period_seconds = chain_list$periodSeconds[i]
     )]
+    # Catch-all: any other chain-level scalar field, prefixed chain_ (no-op when
+    # the schema only has the known fields, e.g. 2026).
+    for (cc in extra_chain) {
+      v <- chain_list[[cc]][i]
+      if (is.atomic(v) && length(v) == 1L) dt[, (paste0("chain_", cc)) := v]
+    }
     dt
   }), fill = TRUE)
 
   if (nrow(chains) == 0) return(data.frame())
 
+  # Match-level fields under fixed names; homeTeamId/awayTeamId get an `mp_`
+  # (matchPlays) prefix so they don't collide with the homeTeamId/awayTeamId that
+  # get_match_chains later joins in from the games/fixtures data (a bare homeTeamId
+  # would suffix to home_team_id_x/_y and break home_team_id resolution). They are
+  # in the SAME id-space as chain_team_id, so clean_pbp can use them as a
+  # self-contained home-end reference for coordinate orientation (issue #92).
   chains[, `:=`(
     matchId = api_response$matchId,
     venueWidth = api_response$venueWidth,
     venueLength = api_response$venueLength,
     homeTeamDirectionQtr1 = api_response$homeTeamDirectionQtr1,
-    # Home/away team ids from the matchPlays response, in the SAME id-space as
-    # chain_team_id. Captured so the coordinate frame's home/away reference is
-    # self-contained from the response that defines (x, y), rather than relying
-    # on the games-join home_team_id (issue #92 API audit). NB: prefixed `mp_`
-    # (matchPlays) so they do NOT collide with the `homeTeamId`/`awayTeamId` that
-    # get_match_chains joins in from the games/fixtures data — a bare homeTeamId
-    # here would suffix to home_team_id_x/_y and break home_team_id resolution.
-    # `filter` is the API's empty query-echo (all NULL), intentionally not captured.
     mp_home_team_id = api_response$homeTeamId,
     mp_away_team_id = api_response$awayTeamId
   )]
+
+  # Catch-all: every other top-level matchPlays scalar field, prefixed mp_, so the
+  # archive is complete and new/older-schema columns never force a re-scrape. The
+  # exploded matchChains array and the empty `filter` query-echo are excluded.
+  known_match <- c("matchId", "venueWidth", "venueLength", "homeTeamDirectionQtr1",
+                   "homeTeamId", "awayTeamId", "matchChains", "chains", "filter")
+  for (mc in setdiff(names(api_response), known_match)) {
+    v <- api_response[[mc]]
+    if (is.atomic(v) && length(v) == 1L) chains[, (paste0("mp_", mc)) := v]
+  }
 
   chains[]
 }

--- a/R/scraper.R
+++ b/R/scraper.R
@@ -408,7 +408,11 @@ get_game_chains <- function(match_id) {
       # action-level stats[j].teamId only says who performed the event (e.g. a
       # spoil/contest by the opponent), so it must NOT be used to decide
       # coordinate orientation. See fix_chain_coordinates_dt() and issue #92.
-      chain_team_id = chain_list$teamId[i]
+      chain_team_id = chain_list$teamId[i],
+      # Chain-level timestamp (seconds into the period). Distinct from the
+      # action-level periodSeconds already on each stats row; named to avoid
+      # collision. Captured for posterity (issue #92 API audit).
+      chain_period_seconds = chain_list$periodSeconds[i]
     )]
     dt
   }), fill = TRUE)
@@ -419,7 +423,14 @@ get_game_chains <- function(match_id) {
     matchId = api_response$matchId,
     venueWidth = api_response$venueWidth,
     venueLength = api_response$venueLength,
-    homeTeamDirectionQtr1 = api_response$homeTeamDirectionQtr1
+    homeTeamDirectionQtr1 = api_response$homeTeamDirectionQtr1,
+    # Home/away team ids in the SAME id-space as chain_team_id. Captured so the
+    # coordinate frame's home/away reference is self-contained from the same
+    # response that defines (x, y), rather than joined in from results-data
+    # (issue #92 API audit). `filter` is the API's empty query-echo (all NULL),
+    # intentionally not captured.
+    homeTeamId = api_response$homeTeamId,
+    awayTeamId = api_response$awayTeamId
   )]
 
   chains[]

--- a/R/scraper.R
+++ b/R/scraper.R
@@ -424,13 +424,16 @@ get_game_chains <- function(match_id) {
     venueWidth = api_response$venueWidth,
     venueLength = api_response$venueLength,
     homeTeamDirectionQtr1 = api_response$homeTeamDirectionQtr1,
-    # Home/away team ids in the SAME id-space as chain_team_id. Captured so the
-    # coordinate frame's home/away reference is self-contained from the same
-    # response that defines (x, y), rather than joined in from results-data
-    # (issue #92 API audit). `filter` is the API's empty query-echo (all NULL),
-    # intentionally not captured.
-    homeTeamId = api_response$homeTeamId,
-    awayTeamId = api_response$awayTeamId
+    # Home/away team ids from the matchPlays response, in the SAME id-space as
+    # chain_team_id. Captured so the coordinate frame's home/away reference is
+    # self-contained from the response that defines (x, y), rather than relying
+    # on the games-join home_team_id (issue #92 API audit). NB: prefixed `mp_`
+    # (matchPlays) so they do NOT collide with the `homeTeamId`/`awayTeamId` that
+    # get_match_chains joins in from the games/fixtures data — a bare homeTeamId
+    # here would suffix to home_team_id_x/_y and break home_team_id resolution.
+    # `filter` is the API's empty query-echo (all NULL), intentionally not captured.
+    mp_home_team_id = api_response$homeTeamId,
+    mp_away_team_id = api_response$awayTeamId
   )]
 
   chains[]

--- a/data-raw/BACKFILL-PLAN.md
+++ b/data-raw/BACKFILL-PLAN.md
@@ -1,0 +1,130 @@
+# Backfill Plan — corrected shot coordinates everywhere (#92)
+
+**Status:** staged / gated. **Owner trigger required for Stages 1–4** (publishing event).
+**Created:** 2026-06-18.
+
+## Why
+
+The #92 chain-coordinate fix (`scraper.R` captures chain-level `teamId` → `clean_pbp`
+orients off the possessing team) is **back-compat by design**: historical chains lack
+`chain_team_id`, so they take the fallback path and reproduce the old buggy `x`. So every
+existing release + the EP/WP/shot models trained on them are still on *uncorrected*
+coordinates. The blog's `add_shot_geometry_variables` band-aid (PR #91) covers legacy
+data only at display time.
+
+**Doing it right = re-scrape all chains with the fixed scraper, rebuild PBP, retrain
+EP→WP→shot on corrected data, and backfill ratings/predictions.** This touches the
+foundational data the entire stack sits on — the biggest blast radius in the system.
+
+The same re-scrape also captures the API fields recovered in the field audit
+(`homeTeamId`, `awayTeamId`, `chain_period_seconds`, fixtures `round_byes`, player
+`team_*`, lineup `team_status` — see `../AFL-API-REFERENCE.md`).
+
+## Orchestrator
+
+`data-raw/rebuild_everything.R` — "nuclear option" with phase gating:
+
+| Phase | What | Skip flag |
+|-------|------|-----------|
+| 1 | API scrape (fixtures/squads/lineups/stats — recovers non-chain captured fields) | `--skip-api` |
+| 2 | **Scrape chains** (enhanced scraper → `chain_team_id`, corrected frame) | `--skip-chains` |
+| 3 | **Build PBP** from chains (`clean_pbp` applies corrected orientation) | `--skip-pbp` |
+| 4 | **Train models** — 4a EP → 4b WP → 4c shot/xG | `--skip-models` |
+| 7 | Stat ratings | `--skip-skills` |
+| 8 | Ratings (TORP/EPR/PSR) | (gated by start) |
+| 9 | Match predictions | `--predictions-only` |
+| 10 | Simulation | `--skip-sim` |
+
+Run via PowerShell (arrow segfaults under Git Bash R):
+`powershell.exe -Command 'Rscript "torp/data-raw/rebuild_everything.R" 2021 2026'`
+
+---
+
+## Stage 0 — `clean_pbp` orientation rewiring (code, NOT a publish)
+
+Make orientation self-contained: prefer the API-sourced `home_team_id` (from the chains
+response that defines `(x,y)`) over the `load_results()` join, with fallback when absent.
+
+- **Files:** `R/clean_pbp.R` (`fix_chain_coordinates_dt` / the `home_team_id` source),
+  possibly `R/column_schema.R` (carry `homeTeamId`/`awayTeamId` through normalisation).
+- **Verify:** unit test on a match where the results-join home/away and the API home/away
+  agree (sanity) + a synthetic case where they'd differ (the fallback/precedence).
+  `devtools::test()` green.
+- **Risk:** low — pure code, no data published. Lands on a branch/PR for review.
+- **Status:** ✅ **done** (2026-06-18). `clean_pbp.R` computes `coord_home_team_id`
+  (prefer API `homeTeamId`, fallback to joined `home_team_id`) and uses it in both
+  orientation steps (A pitch, G action). Verified: strict no-op on current data (no
+  `homeTeamId` → fallback); precedence test proves it follows the API id when the
+  results join is swapped. 53 test blocks, 0 fail. Activates automatically once Stage 1
+  re-scrapes chains carrying `homeTeamId`.
+
+## Stage 1 — re-scrape chains + rebuild PBP (Phases 1–3)
+
+`rebuild_everything.R --skip-models` (or start-from Phase 1) for `2021:2026`.
+
+- **Produces:** new `chains-data` + `pbp-data` releases with `chain_team_id` populated and
+  corrected `x/x_pitch` for the ~7% previously mis-flipped shot rows, plus the newly
+  captured fields.
+- **Verify (before any model retrain):** on several historical matches, shot rows with
+  `x<0`/`goal_x>venue/2` drop to ~0 (mirror the #92 test-match check, 7→0); row counts
+  per season unchanged; `chain_team_id` non-NA for all new rows; spot-check a known goal's
+  coordinates point at the attacking goal.
+- **Rollback:** prior `chains-data`/`pbp-data` release assets (GitHub keeps history; note
+  the asset `updatedAt` before overwrite). Models/ratings still point at old data until
+  Stage 2, so a bad re-scrape is contained here.
+- **Blast radius:** foundational PBP. ~hours of scraping. **Publishing event.**
+- **Status:** ⬜ gated.
+
+## Stage 2 — retrain EP → WP → shot (Phase 4)
+
+`rebuild_everything.R --models-only --training-seasons 2021 <current-1>`.
+**EP must train before WP** (WP uses EP as a feature); shot/xG after.
+
+- **Produces:** retrained EP/WP/shot models in `torpmodels` (+ the live JSON exports in
+  torpmodels for the Worker — confirm those are regenerated, see live-model export note).
+- **Verify:** model-output validators (EP in plausible bounds, WP∈[0,1]); compare holdout
+  metrics vs the pre-retrain models (expect small movement, not a regression);
+  shot/xG calibration sane.
+- **Rollback:** previous model release assets.
+- **Blast radius:** every EP/WP/xG number downstream. **Publishing event.**
+- **Status:** ⬜ gated.
+
+## Stage 3 — backfill ratings + predictions (Phases 8–9)
+
+`run_ratings_pipeline.R` with `SEASONS=TRUE` (all history) → republish `ratings-data`,
+`player_game_ratings-data`, `team_ratings-data`; then match predictions.
+
+- **Verify:** capture a baseline first (per the publishing-events discipline), then diff
+  before→after on representative players/games; low-TOG `torp_value`, PSR historical, and
+  now coordinate-dependent EPV should all move coherently.
+- **Note:** this restacks on top of the #80/#88 corrections already live; expect TORP/EPV
+  to shift again from the coordinate fix. **Needs release notes** (foundational data +
+  model retrain, not just a refresh).
+- **Blast radius:** all published ratings + predictions + blog. **Publishing event.**
+- **Status:** ⬜ gated.
+
+## Stage 4 — blog refresh
+
+Dispatch torpdata `build-blog-data` to pull the corrected parquets to R2; the blog's
+client-side shot-distance band-aid (PR #91 / `add_shot_geometry_variables`) becomes a
+no-op once the upstream `x` is correct — confirm and optionally remove it.
+
+- **Status:** ⬜ gated.
+
+---
+
+## Sequencing & gating
+
+Stage 0 (code) → review/merge → **Stage 1** → verify coords → **Stage 2** → verify models
+→ **Stage 3** → verify ratings → **Stage 4**. Each stage gates the next on verification;
+each of 1–4 is an owner-triggered publishing event. Do NOT chain them blindly — verify
+between stages so a regression is attributable to one stage (same discipline as the
+#80→#88 value republishes and the rename cutover).
+
+## Open questions to resolve before Stage 2
+
+- Are the **live JSON model exports** (torpmodels, consumed by the inthegame-blog Worker
+  `ep-model.js`) regenerated by Phase 4, or a separate step? Confirm so live inference
+  isn't left on stale models.
+- Training season range: default `2021:(current-1)`; confirm whether to include the
+  partial current season.

--- a/data-raw/rebuild_everything.R
+++ b/data-raw/rebuild_everything.R
@@ -107,6 +107,7 @@ skip_sim    <- "--skip-sim" %in% flag_args
 models_only      <- "--models-only" %in% flag_args
 ratings_only     <- "--ratings-only" %in% flag_args
 predictions_only <- "--predictions-only" %in% flag_args
+data_only        <- "--data-only" %in% flag_args  # Phases 1-3 only: re-scrape + PBP, then stop
 
 # "only" flags disable everything else
 if (models_only) {
@@ -119,6 +120,15 @@ if (ratings_only) {
 }
 if (predictions_only) {
   skip_api <- TRUE; skip_chains <- TRUE; skip_pbp <- TRUE
+  skip_models <- TRUE; skip_skills <- TRUE; skip_sim <- TRUE
+}
+if (data_only) {
+  # Re-scrape + rebuild PBP only (Phases 1-3), publish chains/pbp, then stop —
+  # deliberately NOT recomputing models/derived/ratings/predictions, so a
+  # coordinate re-scrape can be verified before any retrain (see BACKFILL-PLAN.md).
+  # Pin start_from = 1 so Phases 1-3 actually run non-interactively (the default
+  # is 6, and start_from is otherwise only lowerable via the interactive prompt).
+  start_from <- 1L
   skip_models <- TRUE; skip_skills <- TRUE; skip_sim <- TRUE
 }
 
@@ -136,10 +146,10 @@ run_api         <- !skip_api && !models_only && !ratings_only && !predictions_on
 run_chains      <- !skip_chains && !models_only && !ratings_only && !predictions_only
 run_pbp         <- !skip_pbp && !models_only && !ratings_only && !predictions_only
 run_models      <- !skip_models && !ratings_only && !predictions_only
-run_derived     <- !models_only && !predictions_only && start_from <= 6
+run_derived     <- !models_only && !predictions_only && !data_only && start_from <= 6
 run_skills      <- !skip_skills && !models_only && !predictions_only
-run_ratings     <- !models_only && !predictions_only && start_from <= 8
-run_predictions <- !models_only && start_from <= 9
+run_ratings     <- !models_only && !predictions_only && !data_only && start_from <= 8
+run_predictions <- !models_only && !data_only && start_from <= 9
 run_sim         <- !skip_sim && !models_only && !ratings_only && !predictions_only
 
 # Season range

--- a/tests/testthat/test-clean-pbp-pipeline.R
+++ b/tests/testthat/test-clean-pbp-pipeline.R
@@ -1091,8 +1091,8 @@ test_that("coord_home_team_id prefers API homeTeamId over results-joined home_te
     chain_number = c(1, 2, 2, 2, 2, 2),
     team_id = rep("1", 6),
     chain_team_id = c("2", "1", "1", "1", "1", "1"),
-    home_team_id = rep("2", 6),   # WRONG: results join had home/away swapped
-    homeTeamId   = rep("1", 6),   # RIGHT: from matchPlays, same id-space as chain_team_id
+    home_team_id    = rep("2", 6),   # WRONG: games join had home/away swapped
+    mp_home_team_id = rep("1", 6),   # RIGHT: from matchPlays, same id-space as chain_team_id
     away_team_id = rep("1", 6),
     home_team_name = rep("Carlton Blues", 6),
     away_team_name = rep("Collingwood Magpies", 6),

--- a/tests/testthat/test-clean-pbp-pipeline.R
+++ b/tests/testthat/test-clean-pbp-pipeline.R
@@ -1076,6 +1076,56 @@ test_that("chain_team_id orientation prevents sign-flip cascade (issue #92)", {
   expect_true(all(team1_rows$x > 0))
 })
 
+test_that("coord_home_team_id prefers API homeTeamId over results-joined home_team_id (issue #92)", {
+  # Same fixture as the sign-flip test, but the results-data join got home/away
+  # BACKWARDS (home_team_id = "2", the actual away team). The matchPlays response
+  # carries the correct homeTeamId = "1" in the same id-space as chain_team_id, so
+  # orientation must follow homeTeamId and still land the team-1 shot on +x. If
+  # the orientation keyed off the wrong joined home_team_id it would flip the
+  # whole team-1 sequence to the defensive half.
+  mock <- data.frame(
+    match_id = rep("CD_M20240140101", 6),
+    display_order = 1:6,
+    period = rep(1L, 6),
+    period_seconds = c(100, 101, 102, 103, 104, 105),
+    chain_number = c(1, 2, 2, 2, 2, 2),
+    team_id = rep("1", 6),
+    chain_team_id = c("2", "1", "1", "1", "1", "1"),
+    home_team_id = rep("2", 6),   # WRONG: results join had home/away swapped
+    homeTeamId   = rep("1", 6),   # RIGHT: from matchPlays, same id-space as chain_team_id
+    away_team_id = rep("1", 6),
+    home_team_name = rep("Carlton Blues", 6),
+    away_team_name = rep("Collingwood Magpies", 6),
+    home_team_abbr = rep("CARL", 6),
+    away_team_abbr = rep("COLL", 6),
+    season = rep(2024L, 6),
+    round_number = rep(1L, 6),
+    venue_length = rep(160, 6),
+    x = c(-45, 45, 45, 46, 46, 46),
+    y = c(44, -44, -40, -33, -30, -30),
+    description = c("Loose Ball Get", "Loose Ball Get", "Handball",
+                    "Handball Received", "Kick", "Behind"),
+    final_state = c(NA, NA, NA, NA, "behind", "behind"),
+    shot_at_goal = c(NA, NA, NA, NA, TRUE, NA),
+    player_position = rep("MID", 6),
+    player_name_given_name = rep("Test", 6),
+    player_name_surname = rep("Player", 6),
+    home_score = rep(50L, 6),
+    away_score = rep(40L, 6),
+    player_id = rep("P1", 6),
+    disposal = rep(NA_character_, 6),
+    stringsAsFactors = FALSE
+  )
+
+  result <- clean_pbp(mock)
+
+  # Orientation followed homeTeamId ("1"), not the swapped home_team_id ("2"):
+  # the team-1 shot stays on the attacking (+x) side near goal.
+  shot <- result[display_order == 5]
+  expect_gt(shot$x, 0)
+  expect_lt(shot$goal_x, shot$venue_length / 2)
+})
+
 test_that("goal_x is recalculated after coordinate fixing", {
   mock <- data.frame(
     match_id = rep("CD_M20240140101", 3),


### PR DESCRIPTION
The code side of the #92 "do it right" work — additive + tested, no data republished. Sets up the gated re-scrape/retrain backfill (`data-raw/BACKFILL-PLAN.md`).

### `ea34d98` — API field audit + capture + dictionary
Audited all 9 AFL API endpoints. **Coordinate-critical finding:** `matchPlays` returns `homeTeamId`/`awayTeamId` in the same id-space as the chain `teamId`, but the scraper dropped them — so orientation depended on a `results-data` join. Now captured. Brought through additively (verified live, tests FAIL 0): matchPlays `homeTeamId`/`awayTeamId`/`chain_period_seconds`, fixtures `round_byes`, player-details `team_*`, lineups `team_status`. Adds `AFL-API-REFERENCE.md` (tracked, build-excluded): all endpoints, every field (type/sample/captured?), release/loader map.

### `3af1df8` — Stage 0: self-consistent orientation
`clean_pbp` computes `coord_home_team_id` (prefer API `homeTeamId`, fallback to joined `home_team_id`) and uses it in both orientation steps. Strict no-op on current data; activates once chains are re-scraped. Precedence test: with the results join *swapped* but `homeTeamId` right, the shot still orients to +x. Adds `BACKFILL-PLAN.md` (Stages 1–4 runbook).

### `4f7f15a` — #88 Gotchas doc (rides along)
CLAUDE.md note on the `load_*()` current-season default trap.

**Captures take effect on the next scrape; the full historical re-scrape + EP/WP/shot retrain + ratings backfill is a separate gated event (BACKFILL-PLAN.md).** 53 clean-pbp test blocks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)