### PR TITLE
ci(pkgdown): deploy docs via native GitHub Actions Pages

### DIFF
--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -9,15 +9,15 @@ on:
 
 name: pkgdown
 
-permissions: read-all
+# Native GitHub Pages deployment (Pages source = "GitHub Actions").
+permissions:
+  contents: read
+  pages: write
+  id-token: write
 
 jobs:
-  pkgdown:
+  build:
     runs-on: ubuntu-latest
-    concurrency:
-      group: pkgdown-${{ github.event_name == 'pull_request' && github.run_id || 'docs' }}
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v6
 
@@ -36,10 +36,23 @@ jobs:
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
         shell: Rscript {0}
 
-      - name: Deploy to GitHub pages
-        if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          clean: false
-          branch: gh-pages
-          folder: docs
+          path: docs
+
+  # Deploy only on push/release/dispatch -- never on pull_request (PRs just build).
+  deploy:
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    concurrency:
+      group: pages
+      cancel-in-progress: false
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Fixes the docs site 404. Pages source is set to **GitHub Actions** (`build_type=workflow`), but the workflow was still pushing to the `gh-pages` branch via `JamesIves/github-pages-deploy-action` — which an Actions-source Pages site ignores. Result: the entire `peteowen1.github.io/torp` site 404'd, including the homepage.

Switches to the official GitHub Pages flow:
- **build** job: builds the pkgdown site and uploads `docs/` via `actions/upload-pages-artifact`
- **deploy** job: publishes it with `actions/deploy-pages` (push/release/dispatch only; PRs just build)

No change to the repo's Pages setting — keeps "GitHub Actions" as the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)