### PR TITLE
Add build_matchup_table to pkgdown reference index

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -148,6 +148,7 @@ reference:
       - extract_player_xg_skill
       - head_to_head
       - print.torp_head_to_head
+      - build_matchup_table
 
   - title: Model Validation
     desc: Evaluate model performance, calibration, and drift


### PR DESCRIPTION
## Summary
- One-line fix for the CI redness since 2026-07-17: adds `build_matchup_table` to the *Match Analysis* section of `_pkgdown.yml`.
- `pkgdown::check_pkgdown()` runs in both the **R Package Tests** and **pkgdown** workflows, so the missing index entry was failing both on every push.

Fixes #111.

## Test plan
- [ ] Both `R Package Tests` and `pkgdown` checks green on this PR (same code path that has been failing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QppyxaM66CLftjv9p1rHkf