### PR TITLE
Release-download retry, HTML-error-page guard, workflow-level VERSEBUS_STRICT

### DIFF
--- a/.github/workflows/daily-ratings-predictions.yml
+++ b/.github/workflows/daily-ratings-predictions.yml
@@ -22,6 +22,7 @@ env:
   GITHUB_PAT: ${{ secrets.WORKFLOW_PAT }}
   R_KEEP_PKG_SOURCE: yes
   piggyback_cache_duration: 1
+  VERSEBUS_STRICT: "1"
 
 concurrency:
   group: ratings-predictions

--- a/R/load_engines.R
+++ b/R/load_engines.R
@@ -381,8 +381,13 @@ parquet_from_url <- function(url) {
   }
 
   tryCatch({
-    # Arrow can read parquet directly from URL
-    load <- arrow::read_parquet(url)
+    # Arrow can read parquet directly from URL. Retries transient failures
+    # (GitHub's release-asset CDN throws sporadic 5xx errors -- torpdata#66/
+    # #68) with a short backoff; a confirmed 404 is never worth retrying.
+    load <- .vb_retry(
+      function() arrow::read_parquet(url),
+      should_retry = function(e) !grepl("404|Not Found", conditionMessage(e), ignore.case = TRUE)
+    )
 
     # Validate that we got actual data
     if (is.null(load)) {

--- a/R/scraper.R
+++ b/R/scraper.R
@@ -163,6 +163,23 @@ get_match_chains <- function(season = get_afl_season(), round = NA) {
 # re-auth on every call during batch scraping sessions.
 .torp_token_cache <- new.env(parent = emptyenv())
 
+#' Detect an HTML error/maintenance page returned where structured data was expected
+#'
+#' AFL's API gateways occasionally return an HTML error page (transient
+#' upstream 5xx/maintenance) with a 200 status and/or a JSON content-type
+#' header, so `httr::stop_for_status()` doesn't catch it and the raw markup
+#' gets thrown straight into `jsonlite::fromJSON()`, whose lexer error
+#' embeds a chunk of the document verbatim (torpdata#71 -- the raw error was
+#' literally `<!DOCTYPE html...`). Sniff the body itself instead: a real API
+#' response never starts with a doctype/html tag.
+#' @param body Character. Response body already read as text.
+#' @return Logical
+#' @keywords internal
+.is_html_error_page <- function(body) {
+  if (is.null(body) || !nzchar(body)) return(FALSE)
+  grepl("^<!DOCTYPE\\s+html|^<html", trimws(body), ignore.case = TRUE)
+}
+
 #' Get API Token
 #'
 #' Retrieves an authentication token for the AFL API, caching it for 5 minutes.
@@ -177,12 +194,27 @@ get_token <- function() {
       difftime(now, .torp_token_cache$fetched, units = "mins") < 5) {
     return(.torp_token_cache$token)
   }
-  response <- httr::POST(paste0(AFL_CFS_API_BASE_URL, "WMCTok"))
-  httr::stop_for_status(response, task = "authenticate with AFL API")
-  token <- httr::content(response)$token
-  if (is.null(token) || !nzchar(token)) {
-    cli::cli_abort("AFL API returned empty or missing token (HTTP 200 but no token in body)")
+  fetch_token <- function() {
+    response <- httr::POST(paste0(AFL_CFS_API_BASE_URL, "WMCTok"))
+    httr::stop_for_status(response, task = "authenticate with AFL API")
+    body <- httr::content(response, as = "text", encoding = "UTF-8")
+    if (.is_html_error_page(body)) {
+      cli::cli_abort(
+        "AFL API auth endpoint returned an HTML error page (likely transient upstream error)",
+        class = "torp_html_error_page"
+      )
+    }
+    parsed <- jsonlite::fromJSON(body)
+    token <- parsed$token
+    if (is.null(token) || !nzchar(token)) {
+      cli::cli_abort("AFL API returned empty or missing token (HTTP 200 but no token in body)")
+    }
+    token
   }
+  token <- .vb_retry(
+    fetch_token,
+    should_retry = function(e) !grepl("404|Not Found", conditionMessage(e), ignore.case = TRUE)
+  )
   .torp_token_cache$token <- token
   .torp_token_cache$fetched <- now
   token
@@ -201,13 +233,25 @@ get_token <- function() {
 #' @importFrom jsonlite fromJSON
 access_api <- function(url) {
   token <- get_token()
-  response <- httr::GET(
-    url = url,
-    httr::add_headers("x-media-mis-token" = token)
+  fetch_and_parse <- function() {
+    response <- httr::GET(
+      url = url,
+      httr::add_headers("x-media-mis-token" = token)
+    )
+    httr::stop_for_status(response, task = paste("fetch data from", url))
+    body <- httr::content(response, as = "text", encoding = "UTF-8")
+    if (.is_html_error_page(body)) {
+      cli::cli_abort(
+        "AFL API returned an HTML error page for {.url {url}} (likely transient upstream error)",
+        class = "torp_html_error_page"
+      )
+    }
+    jsonlite::fromJSON(body, flatten = TRUE)
+  }
+  .vb_retry(
+    fetch_and_parse,
+    should_retry = function(e) !grepl("404|Not Found", conditionMessage(e), ignore.case = TRUE)
   )
-  httr::stop_for_status(response, task = paste("fetch data from", url))
-  httr::content(response, as = "text", encoding = "UTF-8") |>
-    jsonlite::fromJSON(flatten = TRUE)
 }
 
 #' Get Round Games

--- a/R/versebus.R
+++ b/R/versebus.R
@@ -229,8 +229,11 @@ vb_read_manifest <- function(repo, tag, required = FALSE) {
     tmpdir <- tempfile("vb_manifest_")
     dir.create(tmpdir)
     on.exit(unlink(tmpdir, recursive = TRUE), add = TRUE)
-    piggyback::pb_download("bus_manifest.json", dest = tmpdir,
-                           repo = repo, tag = tag, overwrite = TRUE)
+    .vb_retry(
+      function() piggyback::pb_download("bus_manifest.json", dest = tmpdir,
+                                        repo = repo, tag = tag, overwrite = TRUE),
+      should_retry = function(e) vb_classify_error(e) != "absent"
+    )
     jsonlite::fromJSON(file.path(tmpdir, "bus_manifest.json"),
                        simplifyVector = TRUE, simplifyDataFrame = TRUE)
   }
@@ -294,6 +297,34 @@ vb_read_prev_manifest <- function(repo, tag) {
   identical(rawToChar(head), "PAR1") && identical(rawToChar(tail), "PAR1")
 }
 
+#' Retry a fallible operation with short exponential backoff
+#'
+#' GitHub's release-asset CDN throws sporadic 5xx errors (torpdata#66/#68)
+#' that usually clear on a second or third attempt with no code change --
+#' this mirrors the backoff style `save_to_release()` already uses for its
+#' upload-side 404/422 retry. Retries up to `times` attempts total, sleeping
+#' `delays[i]` seconds before each retry (recycled if `times - 1` exceeds
+#' `length(delays)`). `should_retry` lets the caller exclude confirmed-absent
+#' failures (e.g. a real 404) -- those never resolve by waiting.
+#' @param fn zero-arg function to attempt
+#' @param times maximum attempts (default 3: one try + 2 retries)
+#' @param delays seconds to sleep before each retry (default 2, then 5)
+#' @param should_retry function(error) -> logical; FALSE re-raises immediately
+#' @keywords internal
+.vb_retry <- function(fn, times = 3L, delays = c(2, 5), should_retry = function(e) TRUE) {
+  last_err <- NULL
+  for (attempt in seq_len(times)) {
+    out <- tryCatch(list(ok = TRUE, value = fn()), error = function(e) list(ok = FALSE, err = e))
+    if (isTRUE(out$ok)) return(out$value)
+    last_err <- out$err
+    if (attempt >= times || !should_retry(last_err)) break
+    d <- delays[min(attempt, length(delays))]
+    cli::cli_warn("Attempt {attempt} failed ({conditionMessage(last_err)}); retrying in {d}s...")
+    Sys.sleep(d)
+  }
+  stop(last_err)
+}
+
 #' Verified, atomic release-asset download
 #'
 #' Downloads to a tempfile in `dest`'s directory, verifies (parquet magic
@@ -339,8 +370,11 @@ vb_download <- function(repo, tag, name, dest,
   on.exit(unlink(tmpdir, recursive = TRUE), add = TRUE)
 
   tryCatch(
-    piggyback::pb_download(name, dest = tmpdir, repo = repo, tag = tag,
-                           overwrite = TRUE),
+    .vb_retry(
+      function() piggyback::pb_download(name, dest = tmpdir, repo = repo, tag = tag,
+                                        overwrite = TRUE),
+      should_retry = function(e) vb_classify_error(e) != "absent"
+    ),
     error = function(e) {
       .vb_abort("Download of {.val {name}} from {repo}@{tag} failed:
                  {conditionMessage(e)}",

--- a/tests/testthat/test-load_torp_data.R
+++ b/tests/testthat/test-load_torp_data.R
@@ -6,6 +6,35 @@ test_that("parquet_from_url validates input correctly", {
   expect_error(torp:::parquet_from_url("ftp://example.com"), "must start with http")
 })
 
+test_that("parquet_from_url retries a transient failure and succeeds", {
+  calls <- 0L
+  local_mocked_bindings(
+    read_parquet = function(...) {
+      calls <<- calls + 1L
+      if (calls < 2L) stop("simulated 500 from release CDN")
+      data.table::data.table(x = 1L)
+    },
+    .package = "arrow"
+  )
+  result <- torp:::parquet_from_url("https://example.com/file.parquet")
+  expect_identical(calls, 2L)
+  expect_equal(nrow(result), 1L)
+})
+
+test_that("parquet_from_url does not retry a confirmed 404", {
+  calls <- 0L
+  local_mocked_bindings(
+    read_parquet = function(...) {
+      calls <<- calls + 1L
+      stop("HTTP 404 Not Found")
+    },
+    .package = "arrow"
+  )
+  result <- suppressWarnings(torp:::parquet_from_url("https://example.com/missing.parquet"))
+  expect_identical(calls, 1L)
+  expect_equal(nrow(result), 0L)
+})
+
 test_that("generate_urls creates correct URLs", {
   urls <- torp:::generate_urls("test-data", "test_file", seasons = c(2021, 2022))
 

--- a/tests/testthat/test-scraper-mocked.R
+++ b/tests/testthat/test-scraper-mocked.R
@@ -140,6 +140,87 @@ test_that("access_api handles connection errors", {
 })
 
 # -----------------------------------------------------------------------------
+# HTML error page guard (torpdata#71): the AFL API gateway occasionally
+# returns an HTML maintenance/error page with a 200 status where JSON is
+# expected. Sniffing + retrying must happen before the raw markup ever
+# reaches jsonlite::fromJSON().
+# -----------------------------------------------------------------------------
+
+test_that(".is_html_error_page detects doctype/html bodies but not JSON", {
+  expect_true(.is_html_error_page("<!DOCTYPE html><html><body>502 Bad Gateway</body></html>"))
+  expect_true(.is_html_error_page("  <html><head></head></html>"))
+  expect_false(.is_html_error_page('{"token": "abc123"}'))
+  expect_false(.is_html_error_page(""))
+  expect_false(.is_html_error_page(NULL))
+})
+
+test_that("access_api retries an HTML error page and succeeds once the body is valid JSON", {
+  calls <- 0L
+  local_mocked_bindings(
+    GET = function(url, ...) {
+      calls <<- calls + 1L
+      structure(list(status_code = 200L), class = "response")
+    },
+    stop_for_status = function(...) invisible(TRUE),
+    content = function(response, as, encoding) {
+      if (calls < 2L) "<!DOCTYPE html><html><body>502 Bad Gateway</body></html>"
+      else '{"fixtures": []}'
+    },
+    add_headers = function(...) list(),
+    .package = "httr"
+  )
+  local_mocked_bindings(get_token = function() "fake-token")
+
+  result <- suppressWarnings(access_api("https://example.com/fixtures"))
+  expect_identical(calls, 2L)
+  expect_true(is.list(result))
+  expect_true("fixtures" %in% names(result))
+})
+
+test_that("access_api does not retry a confirmed 404", {
+  calls <- 0L
+  local_mocked_bindings(
+    GET = function(url, ...) {
+      calls <<- calls + 1L
+      structure(list(status_code = 404L), class = "response")
+    },
+    stop_for_status = function(response, task) {
+      cli::cli_abort("HTTP 404 Not Found ({task})")
+    },
+    content = function(...) stop("content() should not be called after a 404"),
+    add_headers = function(...) list(),
+    .package = "httr"
+  )
+  local_mocked_bindings(get_token = function() "fake-token")
+
+  expect_error(access_api("https://example.com/missing"), "404")
+  expect_identical(calls, 1L)
+})
+
+test_that("get_token retries an HTML error page and succeeds once the body is valid JSON", {
+  withr::defer(assign("token", NULL, envir = torp:::.torp_token_cache))
+  assign("token", NULL, envir = torp:::.torp_token_cache)
+
+  calls <- 0L
+  local_mocked_bindings(
+    POST = function(url, ...) {
+      calls <<- calls + 1L
+      structure(list(status_code = 200L), class = "response")
+    },
+    stop_for_status = function(...) invisible(TRUE),
+    content = function(response, as, encoding) {
+      if (calls < 2L) "<!DOCTYPE html><html><body>Maintenance</body></html>"
+      else '{"token": "abc123"}'
+    },
+    .package = "httr"
+  )
+
+  tok <- suppressWarnings(get_token())
+  expect_identical(tok, "abc123")
+  expect_identical(calls, 2L)
+})
+
+# -----------------------------------------------------------------------------
 # Mock API Response Structure Tests
 # -----------------------------------------------------------------------------
 

--- a/tests/testthat/test-versebus.R
+++ b/tests/testthat/test-versebus.R
@@ -196,6 +196,41 @@ test_that("vb_atomic_write never leaves a partial dest", {
   expect_length(list.files(dir, pattern = "^\\.vb_", all.files = TRUE), 0)
 })
 
+test_that(".vb_retry succeeds after transient failures within the attempt budget", {
+  calls <- 0L
+  result <- .vb_retry(function() {
+    calls <<- calls + 1L
+    if (calls < 3L) stop("simulated transient failure")
+    "ok"
+  }, times = 3L, delays = c(0, 0))
+  expect_identical(result, "ok")
+  expect_identical(calls, 3L)
+})
+
+test_that(".vb_retry gives up after exhausting attempts and raises the last error", {
+  calls <- 0L
+  expect_error(
+    .vb_retry(function() {
+      calls <<- calls + 1L
+      stop("simulated transient failure")
+    }, times = 3L, delays = c(0, 0)),
+    "simulated transient failure"
+  )
+  expect_identical(calls, 3L)
+})
+
+test_that(".vb_retry does not retry when should_retry returns FALSE", {
+  calls <- 0L
+  expect_error(
+    .vb_retry(function() {
+      calls <<- calls + 1L
+      stop("confirmed absent")
+    }, times = 3L, delays = c(0, 0), should_retry = function(e) FALSE),
+    "confirmed absent"
+  )
+  expect_identical(calls, 1L)
+})
+
 test_that("manifest merge carries forward previous entries on partial publish", {
   prev <- make_fake_manifest(assets = list(
     list(name = "old.parquet", sha256 = strrep("a", 64), bytes = 5, rows = 10L)


### PR DESCRIPTION
Three reliability changes:

1. **`.vb_retry()` retry-with-backoff for release-asset downloads** (fixes peteowen1/torpdata#66, peteowen1/torpdata#68) — GitHub's release CDN throws sporadic 5xx; `vb_download()` and `parquet_from_url()` now retry transient failures (2s/5s backoff), never confirmed 404s. Note: the literal `wp_calibration.rds` error in #66 originates in torpmodels' `download_model_from_release()` — a matching fix is going into torpmodels separately.
2. **HTML-error-page sniff in the AFL API scraper** (fixes peteowen1/torpdata#71) — `get_token()`/`access_api()` detect `<!DOCTYPE html` bodies (gateway error pages served with 200), retry, and fail with a clear message instead of dumping raw HTML into the log.
3. **`VERSEBUS_STRICT=1` at workflow level** in `daily-ratings-predictions.yml` — versebus phase-3 tail (FABLE-C6-SHIP-PLAN step 6), deferred until the C6 retrain ran green (confirmed through 2026-07-20). Entry scripts have set it since 2026-07-11; this makes every step strict.

Tests: `test-versebus.R`, `test-load_torp_data.R`, `test-scraper-mocked.R`, `test-scraper-functions.R` all pass locally (new coverage for the retry helper and HTML sniff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VoedPoJcKaGRUUg8Q1YpJw