### PR TITLE
chore: bump to 1.3.6 + NEWS for torpdata#74 fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: torp
 Title: AFL Analytics and Player Rating System
-Version: 1.3.5
+Version: 1.3.6
 Authors@R: 
     person("Pete", "Owen", , "pete.owen1@hotmail.co.uk", role = c("aut", "cre"))
 Description: Provides tools for Australian Football League (AFL) analytics including 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# torp 1.3.6 (2026-07-23)
+
+## Bug Fixes
+
+* **`save_to_release()` post-upload verify aborted on GitHub release-asset listing lag (torpdata#74)** — the daily data release failed two days running (2026-07-21, 2026-07-22) when a fresh listing call right after upload reported a slightly different asset size than what was just written. Both deltas were small and non-data-shaped, consistent with GitHub's release-asset listing lagging the upload rather than real corruption. The verify now retries the listing + compare through `.vb_retry()` (same backoff already used for download-side flakes, #66/#68) before treating a mismatch as a real integrity failure.
+
 # torp 1.3.4 (2026-05-09)
 
 ## Bug Fixes


### PR DESCRIPTION
## Summary
- Version/NEWS-only follow-up to #119 (already merged) -- no functional changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169n9YpFLYakomp8uZ575vL