### PR TITLE
Widen post-upload verify retry budget (torpdata#74 follow-up)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: torp
 Title: AFL Analytics and Player Rating System
-Version: 1.3.6
+Version: 1.3.7
 Authors@R: 
     person("Pete", "Owen", , "pete.owen1@hotmail.co.uk", role = c("aut", "cre"))
 Description: Provides tools for Australian Football League (AFL) analytics including 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# torp 1.3.7 (2026-07-25)
+
+## Bug Fixes
+
+* **`save_to_release()` post-upload verify retry budget widened (torpdata#74 follow-up)** — the 1.3.6 fix retried the post-upload listing check through `.vb_retry()`'s default budget (3 attempts, 2s+5s delays, ~7s total), but the failure kept recurring on live game days (2026-07-23, 2026-07-24): the listed size was consistently *smaller* than the just-uploaded local size, consistent with GitHub's listing lag outlasting 7s during high-frequency upload bursts, not real corruption. Widened to 5 attempts with 2+3+5+10s delays (~20s total) for this specific verify call.
+
 # torp 1.3.6 (2026-07-23)
 
 ## Bug Fixes

--- a/R/load_data.R
+++ b/R/load_data.R
@@ -111,7 +111,13 @@ save_to_release <- function(df, file_name, release_tag, also_csv = FALSE, prev_r
   # surface. Retried via .vb_retry() (torpdata#74): GitHub's release-asset
   # listing can lag the upload by a few seconds (eventual consistency),
   # which otherwise reads as a spurious missing/wrong-sized asset on the
-  # very next call even though the upload itself was fine. A failure to
+  # very next call even though the upload itself was fine. Widened from the
+  # .vb_retry() default (3 attempts / 2s+5s, ~7s total) to 5 attempts /
+  # 2+3+5+10s (~20s total) after torpdata#74's fix still recurred on live
+  # game days: 2026-07-23/24 failures showed the listed size consistently
+  # SMALLER than the just-uploaded local size (stale-listing lag, not real
+  # corruption) and outlasted the original 7s budget during high-frequency
+  # upload bursts. A failure to
   # even LIST after retries (vb_error_transient from vb_list_assets itself)
   # only warns -- it's evidence the verify call flaked, not that the upload
   # did. A listing that still confirms the asset is genuinely missing or
@@ -139,7 +145,8 @@ save_to_release <- function(df, file_name, release_tag, also_csv = FALSE, prev_r
     invisible(TRUE)
   }
   tryCatch(
-    .vb_retry(verify_upload, should_retry = function(e) vb_classify_error(e) != "absent"),
+    .vb_retry(verify_upload, times = 5L, delays = c(2, 3, 5, 10),
+              should_retry = function(e) vb_classify_error(e) != "absent"),
     error = function(e) {
       if (inherits(e, "vb_verify_list_failed")) {
         cli::cli_warn("Post-upload verify could not list {repo}@{release_tag} after retries ({conditionMessage(e)}) -- upload itself already succeeded, proceeding")

--- a/tests/testthat/test-save-to-release.R
+++ b/tests/testthat/test-save-to-release.R
@@ -1,7 +1,9 @@
 # save_to_release()'s post-upload verify (T12) regression coverage.
 # See torpdata#74: GitHub's release-asset listing can lag the upload by a
 # few seconds (eventual consistency), which the verify used to treat as a
-# hard integrity failure on the very first check.
+# hard integrity failure on the very first check. Retry budget widened
+# 2026-07-25 (3 attempts/~7s -> 5 attempts/~20s, c(2,3,5,10) delays) after
+# the original budget still wasn't enough during live-game upload bursts.
 
 test_that("save_to_release retries the post-upload size verify through a stale GitHub listing, then succeeds", {
   uploaded_bytes <- NULL
@@ -67,7 +69,7 @@ test_that("save_to_release aborts when the post-upload size mismatch persists af
     save_to_release(df, "widget", "test-tag"),
     class = "vb_error_integrity"
   )
-  expect_equal(call_count, 3L)  # exhausted all .vb_retry attempts
+  expect_equal(call_count, 5L)  # exhausted all .vb_retry attempts
 })
 
 test_that("save_to_release warns (not aborts) when the post-upload listing call itself keeps failing", {


### PR DESCRIPTION
## Summary
- The 1.3.6 fix for torpdata#74 retried `save_to_release()`'s post-upload verify through `.vb_retry()`'s default budget (3 attempts, ~7s total), but the failure kept recurring on live AFL game days (2026-07-23, 2026-07-24 confirmed via GH Actions run logs) — in every observed failure, listed size < local size, consistent with GitHub's release-asset listing lag outlasting the original 7s budget during high-frequency upload bursts, not real corruption.
- Widened the retry budget for this specific verify call to 5 attempts / `c(2,3,5,10)` delays (~20s total).
- NEWS.md (v1.3.7) + DESCRIPTION version bump.

## Test plan
- [x] `tests/testthat/test-save-to-release.R` updated (`call_count` assertion 3L -> 5L) and run locally — 5/5 pass, 0 failures
- [x] Code review (Sonnet, medium effort) — approved, no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ciGbk49bKQ1WK91gZ4veH