### PR TITLE
Release torp 1.3.9

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: torp
 Title: AFL Analytics and Player Rating System
-Version: 1.3.8
+Version: 1.3.9
 Authors@R: 
     person("Pete", "Owen", , "pete.owen1@hotmail.co.uk", role = c("aut", "cre"))
 Description: Provides tools for Australian Football League (AFL) analytics including 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# torp (development version)
+# torp 1.3.9 (2026-07-28)
 
 ## Match model
 


### PR DESCRIPTION
Cuts the accumulated `# torp (development version)` NEWS section as **1.3.9** and bumps `DESCRIPTION` to match.

Follows this repo's convention of a version per shipped change — 1.3.6, 1.3.7 and 1.3.8 each got one. `main` was left at 1.3.8 when #124 merged, because the version-bump hook staged its change after the commit rather than into it.

Contents: the xScore power rating replacing the win-based team Elo as the match model's team-strength feature (#124), already merged, retrained and serving.

No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoLWEDS5QnHXTy1Nd6Dfjd