### PR TITLE
Post-upload verify: decide on the timestamp, not the size direction (torpdata#74, 4th iteration)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: torp
 Title: AFL Analytics and Player Rating System
-Version: 1.3.13
+Version: 1.3.14
 Authors@R: 
     person("Pete", "Owen", , "pete.owen1@hotmail.co.uk", role = c("aut", "cre"))
 Description: Provides tools for Australian Football League (AFL) analytics including 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,17 @@
 
 ## Bug Fixes
 
+* **The post-upload verify no longer reads a growing file as a truncated one**
+  (torpdata#74, fourth iteration). `save_to_release()` treated any listing
+  smaller than the local file as a possible truncation and aborted, which failed
+  5 of 8 daily releases on 2026-08-08 — every one of them adding a new round to
+  `pbp_data_2026_all.parquet`, where the season file grows and a lagging listing
+  therefore serves the previous, *smaller* asset. Size direction turns out to
+  carry no information in either direction, so the decision now rests entirely
+  on the listing's own `updated_at`: a row stamped before our upload is a
+  previous asset (retry, then warn and proceed), and a row stamped at or after
+  it is our write, so short means truncation and long means a failed replace.
+
 * **The positional level correction moved to EPV, where the gap is actually
   created.** `.position_adjust()` already centred every EPV channel to
   machine-precision zero — but by `lineup_position`, the weekly on-field role.

--- a/R/load_data.R
+++ b/R/load_data.R
@@ -136,24 +136,38 @@ save_to_release <- function(df, file_name, release_tag, also_csv = FALSE, prev_r
   # wait, a stale read of an older asset never does, which is exactly why more
   # retries changed nothing.
   #
-  # What we key the decision on: TRUNCATION is the failure worth aborting for,
-  # and truncation makes the listing SMALLER than what we wrote. That direction
-  # stays fatal.
+  # FOURTH iteration (2026-08-09). The third kept "listed SMALLER than local"
+  # fatal, on the reasoning that truncation makes a file short and that
+  # direction is therefore unambiguous. It is not, and the release failed 5 of
+  # 8 runs on 2026-08-08 proving it:
   #
-  # A LARGER listing is ambiguous, and an earlier version of this fix got it
-  # wrong by treating "larger" as self-evidently a stale read. It is equally
-  # consistent with a FAILED REPLACE (piggyback's delete-then-upload is not
-  # atomic -- if the delete loses a race the old, bigger asset stays live while
-  # pb_upload() still returns 2xx) or with a CONCURRENT WRITER overwriting us.
-  # Size direction alone cannot separate those from a lagging listing.
+  #   Post-upload verify: "pbp_data_2026_all.parquet"
+  #     listed size 73694060 < local 74776757 -- possible truncated upload
   #
-  # So the larger-than case is decided on a real staleness signal instead --
-  # the listing's own updated_at versus when we started our upload:
-  #   listed <  local                          -> integrity error, fatal
-  #   listed >  local, updated_at OLDER than us -> listing has not caught up
-  #                                                yet; retry, then warn+proceed
-  #   listed >  local, updated_at NEWER than us -> something else wrote this
-  #                                                asset after we did; fatal
+  # That run was "Updating pbp_data_2026_all with round 22". 73694060 is the
+  # PRE-round-22 asset; the live asset now reads 75153518, i.e. every one of
+  # those writes landed. The season file GROWS on each round, so a listing that
+  # has not caught up serves the previous, SMALLER asset -- the same lagging
+  # read the third iteration diagnosed, arriving from the other direction. The
+  # third iteration saw LARGER because it was reading same-round re-writes,
+  # where a re-encoded parquet differs by a few hundred bytes either way.
+  #
+  # So size direction carries no information about which failure this is, in
+  # EITHER direction, and the decision belongs entirely to the staleness signal
+  # the third iteration already introduced -- the listing's own updated_at
+  # versus when we started our upload:
+  #   updated_at OLDER than us -> the row is a previous asset and the listing
+  #                               has not caught up; retry, then warn+proceed
+  #   updated_at AT/AFTER us   -> the row IS our write, so the size mismatch is
+  #                               real: short means truncation, long means a
+  #                               failed replace or a concurrent writer. Fatal.
+  #
+  # A LARGER listing was never self-evidently a stale read either. It is
+  # equally consistent with a FAILED REPLACE (piggyback's delete-then-upload is
+  # not atomic -- if the delete loses a race the old, bigger asset stays live
+  # while pb_upload() still returns 2xx) or with a CONCURRENT WRITER. Same
+  # applies to smaller. That is the whole point: only the timestamp separates
+  # them.
   #
   # Note the previous iteration of this comment claimed truncation was
   # "independently guarded by the row-count floor against bus_manifest.json".
@@ -185,14 +199,10 @@ save_to_release <- function(df, file_name, release_tag, also_csv = FALSE, prev_r
     local_bytes <- as.numeric(file.size(tf))
     listed_bytes <- as.numeric(row$size[1L])
     if (!isTRUE(all.equal(listed_bytes, local_bytes))) {
-      if (listed_bytes < local_bytes) {
-        .vb_abort("Post-upload verify: {.val {f_name}} listed size {listed_bytes} < local {local_bytes} -- possible truncated upload",
-                  "vb_error_integrity")
-      }
-      # Larger than ours: only a listing that predates our own upload is
-      # evidence of a lagging read. One stamped at or after our upload is
-      # evidence of a different, later write -- a failed replace or a
-      # concurrent writer -- and must stay fatal.
+      # Same phrase in every branch below, so the direction is always visible in
+      # the log even when the decision did not turn on it.
+      direction <- if (listed_bytes < local_bytes) "<" else ">"
+      sizes <- paste("listed size", listed_bytes, direction, "local", local_bytes)
       listed_at <- suppressWarnings(
         as.POSIXct(row$updated_at[1L], format = "%Y-%m-%dT%H:%M:%SZ", tz = "UTC")
       )
@@ -202,15 +212,24 @@ save_to_release <- function(df, file_name, release_tag, also_csv = FALSE, prev_r
       # "a different write replaced ours" message would otherwise hunt a
       # phantom concurrent writer instead of an API shape change.
       if (is.na(listed_at)) {
-        .vb_abort("Post-upload verify: {.val {f_name}} listed size {listed_bytes} > local {local_bytes}, and updated_at {.val {row$updated_at[1L]}} could not be parsed -- treating the staleness signal as untrusted",
+        .vb_abort("Post-upload verify: {.val {f_name}} {sizes}, and updated_at {.val {row$updated_at[1L]}} could not be parsed -- treating the staleness signal as untrusted",
                   "vb_error_integrity")
       }
+      # A row stamped before our own upload is a previous asset, whichever way
+      # its size falls: the season files grow on each round, so a lagging
+      # listing reads SMALLER, and a same-round re-encode reads either way.
       stale_read <- listed_at < (upload_started_at - VB_VERIFY_CLOCK_SKEW_SECS)
       if (stale_read) {
-        .vb_abort("Post-upload verify: {.val {f_name}} listed size {listed_bytes} > local {local_bytes}, listing stamped {row$updated_at[1L]} (before our upload) -- lagging listing",
+        .vb_abort("Post-upload verify: {.val {f_name}} {sizes}, listing stamped {row$updated_at[1L]} (before our upload) -- lagging listing",
                   c("vb_error_transient", "vb_verify_stale_listing"))
       }
-      .vb_abort("Post-upload verify: {.val {f_name}} listed size {listed_bytes} > local {local_bytes}, listing stamped {row$updated_at[1L]} (at or after our upload) -- a different write replaced ours, or the replace failed and the old asset is still live",
+      # Stamped at or after our upload, so this row IS our write and the size
+      # mismatch is real.
+      if (listed_bytes < local_bytes) {
+        .vb_abort("Post-upload verify: {.val {f_name}} {sizes}, listing stamped {row$updated_at[1L]} (at or after our upload) -- our own write is short, i.e. a truncated upload",
+                  "vb_error_integrity")
+      }
+      .vb_abort("Post-upload verify: {.val {f_name}} {sizes}, listing stamped {row$updated_at[1L]} (at or after our upload) -- a different write replaced ours, or the replace failed and the old asset is still live",
                 "vb_error_integrity")
     }
     invisible(TRUE)
@@ -238,7 +257,7 @@ save_to_release <- function(df, file_name, release_tag, also_csv = FALSE, prev_r
         cli::cli_warn("Post-upload verify could not list {repo}@{release_tag} after retries ({conditionMessage(e)}) -- upload itself already succeeded, proceeding")
       } else if (inherits(e, "vb_verify_stale_listing")) {
         cli::cli_warn(c(
-          "Post-upload verify still reading a larger, older-stamped asset for {.val {f_name}} after retries ({conditionMessage(e)}) -- proceeding.",
+          "Post-upload verify still reading an older-stamped asset for {.val {f_name}} after retries ({conditionMessage(e)}) -- proceeding.",
           "i" = "pb_upload() returned success and the listing predates our own upload, so this is a lagging read rather than a lost write.",
           "!" = "This is not a proof of correctness. If it recurs on the same file, check the asset's real bytes rather than trusting the listing."
         ))

--- a/tests/testthat/test-save-to-release.R
+++ b/tests/testthat/test-save-to-release.R
@@ -39,7 +39,9 @@ test_that("save_to_release retries the post-upload size verify through a stale G
   expect_equal(call_count, 2)
 })
 
-test_that("save_to_release aborts when the listing stays SMALLER than local (possible truncation)", {
+test_that("save_to_release ABORTS when a SMALLER listing is stamped AFTER our upload (truncation)", {
+  # The row is stamped at/after our own write, so it IS our write and it is
+  # short. That is the truncation signature and must stay fatal.
   uploaded_bytes <- NULL
   testthat::local_mocked_bindings(
     pb_upload = function(file, repo, tag, overwrite = TRUE, ...) {
@@ -53,10 +55,9 @@ test_that("save_to_release aborts when the listing stays SMALLER than local (pos
   testthat::local_mocked_bindings(
     gh = function(endpoint, ...) {
       call_count <<- call_count + 1
-      # Persistently SMALLER than what we wrote -- the truncation signature,
-      # which must stay fatal (torpdata#74 third iteration).
+      # Far-future stamp -> unambiguously at or after this run's upload.
       list(assets = list(list(name = "widget.parquet", size = uploaded_bytes - 4,
-                              updated_at = "2026-07-22T00:00:00Z", id = 1)))
+                              updated_at = "2099-01-01T00:00:00Z", id = 1)))
     },
     .package = "gh"
   )
@@ -71,6 +72,48 @@ test_that("save_to_release aborts when the listing stays SMALLER than local (pos
     class = "vb_error_integrity"
   )
   expect_equal(call_count, 5L)  # exhausted all .vb_retry attempts
+})
+
+test_that("save_to_release warns when a SMALLER listing is stamped BEFORE our upload (lagging read)", {
+  # torpdata#74, FOURTH iteration (2026-08-09). The third kept every
+  # smaller-than-local listing fatal on the reasoning that truncation makes a
+  # file short. But the season files GROW on each round, so a listing that has
+  # not caught up serves the previous, smaller asset. On 2026-08-08 that failed
+  # 5 of 8 daily releases: listed 73694060 < local 74776757 while adding round
+  # 22, and the live asset afterwards read 75153518 -- every write had landed.
+  # Size direction carries no information here; only the timestamp does.
+  uploaded_bytes <- NULL
+  testthat::local_mocked_bindings(
+    pb_upload = function(file, repo, tag, overwrite = TRUE, ...) {
+      uploaded_bytes <<- file.size(file)
+      invisible(NULL)
+    },
+    .package = "piggyback"
+  )
+
+  call_count <- 0
+  testthat::local_mocked_bindings(
+    gh = function(endpoint, ...) {
+      call_count <<- call_count + 1
+      # Smaller AND stamped well in the past -> the previous asset. (Scaled
+      # down from the real 1,082,697-byte gap; the fixture frame is tiny and a
+      # negative size would be testing an impossible listing.)
+      list(assets = list(list(name = "widget.parquet", size = uploaded_bytes - 4,
+                              updated_at = "2020-01-01T00:00:00Z", id = 1)))
+    },
+    .package = "gh"
+  )
+  testthat::local_mocked_bindings(
+    .publish_bus_manifest = function(...) invisible(NULL),
+    save_locally = function(...) invisible(NULL)
+  )
+
+  df <- data.frame(x = 1:3, y = c("a", "b", "c"))
+  expect_warning(
+    save_to_release(df, "widget", "test-tag"),
+    "lagging|older-stamped"
+  )
+  expect_equal(call_count, 5L)  # still retried the full budget before giving up
 })
 
 test_that("save_to_release warns when a LARGER listing is stamped BEFORE our upload (lagging read)", {


### PR DESCRIPTION
## What broke

torpdata's Daily Data Release failed **5 of 8 runs on 2026-08-08** (06:05, 08:04, 10:26, 13:25, 14:05), plus 2026-08-07 14:29. Every one identical:

```
Post-upload verify: "pbp_data_2026_all.parquet"
  listed size 73694060 < local 74776757 -- possible truncated upload
```

All four retries exhausted on a byte-identical reading, so nothing converged. Each red run files or comments on an issue (torpdata#74, #76). Data still flowed — later runs went green — so this was erosion and noise, not an outage.

## Why the previous fix could not catch it

The third iteration (2026-07-28) kept "listed SMALLER than local" fatal, reasoning that truncation makes a file short and that direction is therefore unambiguous.

It is not. That run was **adding round 22**, and the season files **grow** each round, so a listing that has not caught up serves the previous, *smaller* asset:

| | bytes |
|---|---|
| listing returned (pre-round-22 asset) | 73,694,060 |
| local file we wrote | 74,776,757 |
| **live asset now** | **75,153,518** |

The live asset is larger than the write that "failed truncation" verification, so every one of those writes landed. The third iteration only ever observed the LARGER direction because it was reading same-round re-writes, where a re-encoded parquet differs by a few hundred bytes either way.

## The change

Size direction carries no information about which failure occurred, in **either** direction. The decision now rests entirely on the staleness signal the third iteration already introduced, applied symmetrically:

| listing `updated_at` | verdict |
|---|---|
| **before** our upload | a previous asset — lagging listing. Retry, then warn and proceed |
| **at or after** our upload | this row IS our write, so the mismatch is real: **short → truncation**, long → failed replace or concurrent writer. Fatal |

The truncation guard still fires; it now fires where it can mean something. Error messages carry the direction and the timestamp so the next diagnosis needs no log archaeology.

## Known limitation, stated rather than buried

A genuine truncation whose listing also lags will now be warned-and-proceeded rather than aborted. That was already true in the larger direction, and the warning says explicitly that it is not proof of correctness. The stronger check would be a row-count floor against `bus_manifest.json` — `prev_rows_floor` exists but defaults to NULL and no `save_to_release()` call site passes it, so it is inert in production today. Wiring it up is the natural follow-up and is **not** in this PR.

## Scope

`main`, not `dev`, is what runs in production: `torpdata/.github/workflows/daily-data-release.yml:71` checks torp out with no `ref:`, so the daily release executes the default branch. This is deliberately a small PR straight to `main` so the fix is not coupled to PR #137, which changes every published rating and needs a separate decision.

Two files. No rating code touched, no exports changed, no schema change.

## Testing

`tests/testthat/test-save-to-release.R` covers all six branches; the one asserting the superseded premise was rewritten rather than deleted, and its replacement encodes the real 08-08 numbers. Full local `R CMD check` on this fix's parent commit: 0 ERRORs, `FAIL 0 | SKIP 17 | PASS 2718`.

## Review

Reviewed inline, single-pass, by the authoring session — agents were not authorised in this session, so this did **not** get the usual multi-agent pre-PR pass. Flagging that explicitly rather than letting the gate look satisfied. The diff is ~75 lines in one file plus tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)