### PR TITLE
Say which path the team TORP switch actually changes (#149)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,8 +10,16 @@
   exactly like "no data" and every simulation silently fell through to a
   player-TORP fallback. The lookup now resolves `team_torp` first, then
   `team_epr`, and `run_ratings_pipeline.R` publishes `team_torp`.
-  **This changes published output**: simulated margins widen ~19% and 4 of 18
-  teams move more than 2 ladder places. `team_torp` was chosen on measurement —
+  **This changes the non-injury-aware path only**: on it, simulated margins
+  widen ~19% and 4 of 18 teams move more than 2 ladder places. **It does not
+  change the simulations published to inthegame.blog.** Those pass injuries, so
+  `use_injury_aware` is `TRUE`, the whole team-ratings lookup is skipped
+  (`R/season_sim.R`, `if (!use_injury_aware)`), and team ratings are built live
+  from player TORP with injured players excluded. Verified on the first blog
+  build after this merged: torpdata run 31661873642, `torp_sha 0d2676a`, logging
+  `Building injury-aware team ratings from player TORP (top 21 per team)`.
+  Whether the published path *should* use `team_torp` is open and unmeasured —
+  see torp#149. `team_torp` was chosen on measurement —
   it wins every scale-free comparison against `team_epr` and `team_psr` — see
   `../docs/reviews/2026-08-12-TEAM-RATING-CALIBRATION.md`, which also records what
   the first pass of that analysis got wrong. Releases published before

--- a/R/season_sim.R
+++ b/R/season_sim.R
@@ -113,7 +113,20 @@ prepare_sim_data <- function(season, team_ratings = NULL, fixtures = NULL,
     sim_teams <- NULL
 
     # When injuries provided, skip pre-computed team ratings and go straight
-    # to player-level ratings so injured players can be excluded
+    # to player-level ratings so injured players can be excluded.
+    #
+    # KNOW WHAT THIS GATE COSTS BEFORE TUNING ANYTHING BELOW IT. The blog's
+    # published simulations (torpdata build-blog-data -> afl/simulations.parquet)
+    # pass injuries, so they take the OTHER branch and never read team_torp at
+    # all. Everything inside this `if` -- the team_torp/team_epr resolution, the
+    # degenerate-column demotion, the measured estimator choice -- applies to
+    # backtests and to callers that pass no injuries. Confirmed on the first
+    # blog build after the team_torp switch merged (torpdata run 31661873642,
+    # torp_sha 0d2676a): "Building injury-aware team ratings from player TORP".
+    #
+    # Whether the published path SHOULD use team_torp is open: it trades the
+    # better-measured estimator for knowing who is actually available, and
+    # nobody has measured which wins. torp#149.
     if (!use_injury_aware) {
       # Pre-computed team ratings are the PREFERRED estimator, and as of
       # 2026-08-12 they are reachable again. Between the metric-first rename


### PR DESCRIPTION
Closes the documentation half of #149. **Comment and prose only — no behaviour
change.** `R/season_sim.R` parse-verified.

## The claim that was wrong

`NEWS.md` said of the #148 team-TORP switch:

> **This changes published output**: simulated margins widen ~19% and 4 of 18
> teams move more than 2 ladder places.

True of the non-injury-aware path. **Not true of what inthegame.blog publishes.**

## Why

`prepare_sim_data()` gates the entire team-ratings branch — the
`team_torp` → `team_epr` → `torp` resolution, the degenerate-column demotion,
the measured estimator choice — behind `if (!use_injury_aware)`. The blog build
passes injuries, so `use_injury_aware` is `TRUE`, `sim_teams` stays `NULL`, and
control falls through to `torp_ratings(season, injuries = injuries)`, which
builds team ratings live from player TORP with injured players excluded.

Confirmed on the first blog build after #148 merged — torpdata run
[31661873642](https://github.com/peteowen1/torpdata/actions/runs/31661873642),
running `torp_sha 0d2676a` (the #148 merge commit):

```
Running 3000 injury-aware season simulations for 2026 from round 22 ...
ℹ Building injury-aware team ratings from player TORP (top 21 per team)
ℹ Excluded 156 injured players from team ratings
```

That `ℹ` line is emitted only on the player-ratings path (its label comes from
`if (use_injury_aware) "injury-aware" else "standard"`).

## What is NOT wrong

The switch works and `team_torp` is published and healthy — read straight off
the `team_ratings-data` release: 18 teams at 2026 R23, 18 distinct finite
values, sd 17.06, so the new `usable` demotion guard correctly does not fire.
The calibration measurement stands. Only the description of the blast radius
was off — and off in the direction that matters, since a reader would have gone
hunting for a ladder change on the site that never happened.

## Changes

- **`NEWS.md`** — scope the claim to the non-injury-aware path, state plainly
  that the blog's simulations are unaffected and why, cite the verifying run,
  and point at #149 for the open question.
- **`R/season_sim.R`** — the same warning at the gate itself, where anyone
  tuning the estimator will be reading, rather than only in a changelog.

## Left open deliberately

The second half of #149: whether the published path *should* use `team_torp`.
It trades the better-measured estimator for knowing who is actually available,
and nobody has measured which wins — the calibration review compares team-rating
columns against each other, not against the injury-aware player build. Noted at
the gate and in the issue rather than guessed at here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACrDta9pqRFveLKGoSGBZm
