### PR TITLE
Price injured players at replacement, not at their own team's average (#151)

### DIFF
--- a/R/season_sim.R
+++ b/R/season_sim.R
@@ -14,6 +14,63 @@
 # Data preparation
 # --------------------------------------------------------------------------
 
+#' Aggregate player TORP into a team rating, pricing absences at replacement
+#'
+#' Split out of `prepare_sim_data()` so the injury behaviour is testable without
+#' standing up fixtures and a full simulation (torp#151).
+#'
+#' The denominator is the FULL squad's `pred_tog`, not the available squad's.
+#' Re-normalising over who is left makes the weights sum to 18 no matter how many
+#' players are missing, which hands the injured players' minutes to the remaining
+#' RATED players — so the implicit replacement becomes the team's own average.
+#' Measured on 2026 R23 that ranged -2.01 (Richmond) to +1.16 (Hawthorn) and
+#' correlated +0.945 with team rating: injuries hurt strong teams less, purely as
+#' an artefact of the aggregation.
+#'
+#' Vacated weight is instead priced at an explicit replacement level: the mean
+#' torp of players outside each squad's top 22 by `pred_tog`, taken from the
+#' pre-exclusion frame so injuries cannot move it. Holding the denominator alone
+#' is not enough — `torp` is centred at 0, so a bare hole credits missing players
+#' with league-average value.
+#'
+#' Validated over 17 injury snapshots spanning 15 rounds (224 team-observations
+#' where a team lost above-replacement players): violations of "losing
+#' above-replacement players must lower your rating" fall from 93 (41.5%) to 0.
+#' Teams with nobody out are unchanged — the vacated weight is exactly 0.
+#'
+#' @param pr_dt player ratings AFTER any injury exclusion
+#' @param pr_dt_full player ratings BEFORE exclusion, or NULL when not
+#'   injury-aware (in which case the two are the same frame)
+#' @param discount scalar applied to the finished team rating
+#' @return a data.table of `team`, `torp`
+#' @keywords internal
+.aggregate_team_torp <- function(pr_dt, pr_dt_full = NULL, discount = 1) {
+  pr_dt <- data.table::as.data.table(pr_dt)
+  squad <- data.table::as.data.table(
+    if (!is.null(pr_dt_full)) pr_dt_full else pr_dt)
+
+  full_tog <- squad[, .(team_tog = sum(pred_tog, na.rm = TRUE)), by = team]
+
+  squad_r <- data.table::copy(squad)
+  squad_r[, tog_rnk := data.table::frank(-pred_tog, ties.method = "first"),
+          by = team]
+  repl_torp <- squad_r[tog_rnk > SIM_TOP_N_PLAYERS + 1, mean(torp, na.rm = TRUE)]
+  if (!is.finite(repl_torp)) repl_torp <- 0
+
+  d <- merge(pr_dt, full_tog, by = "team", all.x = TRUE)
+  d[, tog_wt := {
+    n_pl <- .N
+    if (isTRUE(team_tog[1] > 0)) pred_tog * 18 / team_tog else rep(18 / n_pl, n_pl)
+  }, by = team]
+
+  d[, .(
+    # 18 - sum(tog_wt) is the weight vacated by excluded players, and is exactly
+    # 0 when nobody is out — so the no-injury path is bit-identical to before.
+    torp = (sum(torp * tog_wt, na.rm = TRUE) +
+              max(18 - sum(tog_wt, na.rm = TRUE), 0) * repl_torp) * discount
+  ), by = team]
+}
+
 #' Prepare simulation data for a season
 #'
 #' Loads fixtures, team ratings, and (optionally) predictions, then separates
@@ -329,15 +386,27 @@ prepare_sim_data <- function(season, team_ratings = NULL, fixtures = NULL,
       # pred_tog-weighted aggregation: torp is now per-80 (centered around 0),
       # so negative values are intentional (below-average players). No pmax guard
       # needed — TOG weighting handles contribution scaling.
+      #
+      # The denominator is the FULL squad's pred_tog, not the available squad's
+      # (torp#151). Re-normalising over who is left makes the weights sum to 18
+      # regardless of how many players are missing, so the injured players'
+      # minutes get handed to the remaining RATED players -- i.e. the implicit
+      # replacement is the team's own average. Measured on 2026 R23 that ranged
+      # -2.01 (Richmond) to +1.16 (Hawthorn) and correlated +0.945 with team
+      # rating: injuries hurt strong teams less, purely as an artefact.
+      #
+      # Instead, vacated weight is priced at an explicit replacement level --
+      # the mean torp of players outside each squad's top 22 by pred_tog,
+      # computed from the pre-exclusion frame so injuries cannot move it.
+      # Holding the denominator alone is NOT enough: torp is centred at 0, so a
+      # bare hole credits missing players with league-average value.
+      #
+      # Validated over 17 injury snapshots spanning 15 rounds (224 team-obs
+      # where a team lost above-replacement players): violations of "losing
+      # above-replacement players must lower your rating" fall from 93 (41.5%)
+      # to 0. Teams with nobody out are bit-identical either way.
       if ("pred_tog" %in% names(pr_dt)) {
-        pr_dt[, tog_wt := {
-          team_sum <- sum(pred_tog, na.rm = TRUE)
-          n_pl <- .N
-          if (team_sum > 0) pred_tog * 18 / team_sum else rep(18 / n_pl, n_pl)
-        }, by = team]
-        sim_teams <- pr_dt[, .(
-          torp = sum(torp * tog_wt, na.rm = TRUE) * discount
-        ), by = team]
+        sim_teams <- .aggregate_team_torp(pr_dt, pr_dt_full, discount)
       } else {
         pr_dt[, tm_rnk := rank(-torp), by = team]
         sim_teams <- pr_dt[tm_rnk <= SIM_TOP_N_PLAYERS, .(

--- a/tests/testthat/test-injury-replacement-level.R
+++ b/tests/testthat/test-injury-replacement-level.R
@@ -1,0 +1,96 @@
+# torp#151. The injury adjustment used to renormalise tog_wt to 18 over the
+# AVAILABLE squad, which meant the implicit replacement player was the team's own
+# average -- so injuries hurt strong teams less. These pin the two properties that
+# failed, on frames prepare_sim_data() actually builds ratings from.
+
+.squad <- function(team, torps, tog = 0.4) {
+  data.frame(
+    player_id = paste0(team, "_", seq_along(torps)),
+    player_name = paste0(team, " Player ", seq_along(torps)),
+    team = team, season = 2026L, round = 1L,
+    torp = torps, pred_tog = tog, stringsAsFactors = FALSE
+  )
+}
+
+# 44-man squad: 22 regulars, then a clearly below-replacement tail.
+.mk <- function(team, star_torp) {
+  .squad(team, c(star_torp, rep(2, 21), rep(-4, 22)))
+}
+
+# Calls the SHIPPED aggregator, not a copy of it. If .aggregate_team_torp()
+# regresses to renormalising over the available squad, these tests fail —
+# verified by mutation, see the final test in this file.
+.rate <- function(df, out_names = character(0)) {
+  full <- data.table::as.data.table(df)
+  avail <- full[!player_name %in% out_names]
+  .aggregate_team_torp(avail, full, discount = 1)$torp
+}
+
+# The pre-#151 behaviour, kept only so the mutation test can prove these
+# assertions actually discriminate.
+.rate_old <- function(df, out_names = character(0)) {
+  d <- data.table::as.data.table(df)[!player_name %in% out_names]
+  d[, tog_wt := {
+    s <- sum(pred_tog, na.rm = TRUE); n_pl <- .N
+    if (s > 0) pred_tog * 18 / s else rep(18 / n_pl, n_pl)
+  }, by = team]
+  d[, .(torp = sum(torp * tog_wt, na.rm = TRUE)), by = team]$torp
+}
+
+test_that("a team with nobody out is bit-identical to the no-injury rating", {
+  df <- .mk("Anytown", 10)
+  expect_identical(.rate(df, character(0)), .rate(df, character(0)))
+  # and the vacated weight really is zero, so the replacement term cannot bite
+  d <- data.table::as.data.table(df)
+  expect_equal(sum(d$pred_tog * 18 / sum(d$pred_tog)), 18)
+})
+
+test_that("losing an ABOVE-replacement player lowers the rating", {
+  df <- .mk("Anytown", 10)
+  base <- .rate(df, character(0))
+  hurt <- .rate(df, "Anytown Player 1")   # torp 10, far above replacement
+  expect_lt(hurt, base)
+})
+
+test_that("losing a BELOW-replacement player RAISES the rating", {
+  # This is why the naive anchor ("any loss must hurt") is wrong: a player worse
+  # than his own replacement is addition by subtraction. Player 44 is at -10
+  # against a replacement level of about -4.3, so the gain must be strictly
+  # positive -- not merely non-negative, which the flat -4 tail satisfied only
+  # to floating-point noise.
+  df <- .mk("Anytown", 10)
+  df$torp[44] <- -10
+  base <- .rate(df, character(0))
+  out <- .rate(df, "Anytown Player 44")
+  expect_gt(out, base + 1e-9)
+})
+
+test_that("the implicit replacement level does not track team strength", {
+  # The defect: under the old renormalise-over-available scheme, the same injury
+  # cost a strong team less than a weak one. Same player quality removed from
+  # both, so the drop should be near-identical.
+  strong <- .mk("Strongtown", 10); weak <- .mk("Weaktown", 10)
+  weak$torp[2:22] <- -2                      # much weaker supporting cast
+  d_strong <- .rate(strong, character(0)) - .rate(strong, "Strongtown Player 1")
+  d_weak   <- .rate(weak, character(0))   - .rate(weak, "Weaktown Player 1")
+  expect_equal(d_strong, d_weak, tolerance = 1e-8)
+})
+
+test_that("MUTATION: these assertions fail against the pre-#151 aggregation", {
+  # A gate that passes on both the fixed and the broken implementation is worse
+  # than no gate. Prove the discrimination rather than assuming it.
+  strong <- .mk("Strongtown", 10); weak <- .mk("Weaktown", 10)
+  weak$torp[2:22] <- -2
+  old_strong <- .rate_old(strong, character(0)) - .rate_old(strong, "Strongtown Player 1")
+  old_weak   <- .rate_old(weak, character(0))   - .rate_old(weak, "Weaktown Player 1")
+  expect_false(isTRUE(all.equal(old_strong, old_weak, tolerance = 1e-8)))
+
+  # The headline symptom, in the band where the two schemes actually disagree:
+  # a player ABOVE his replacement but BELOW his team's own average. The old
+  # scheme replaces him with the team average and so RAISES the rating; the new
+  # one replaces him with replacement level and so LOWERS it.
+  df <- .mk("Anytown", 10)
+  df$torp[44] <- -2            # replacement ~= -3.9, team average ~= -0.8
+  expect_gt(.rate_old(df, "Anytown Player 44"), .rate_old(df, character(0)))
+  expect_lt(.rate(df, "Anytown Player 44"), .rate(df, character(0)))
+})


### PR DESCRIPTION
Fixes #151. Unblocks #149.

> **Please don't merge on my say-so.** This changes published ladder numbers, and
> the definition of replacement level is a judgement call that moves every team's
> rating. Reviewed inline by me only — no agents were authorised this session.

## The defect

`prepare_sim_data()` renormalised `tog_wt` to sum to 18 over the **available**
squad, so the weights totalled 18 however many players were missing. Injured
players' minutes went to the remaining **rated** players — making the implicit
replacement *the team's own average*:

| team | implicit replacement |
|---|---|
| Hawthorn | **+1.16** |
| Geelong | +1.00 |
| West Coast | −1.50 |
| Richmond | **−2.01** |

`cor(implicit_repl, team rating) = +0.945`. **Injuries hurt strong teams less,
purely as an artefact.** Injured players hold 18.1% of squad `pred_tog`, so it is
not a rounding effect. Same shape as the 0.95 discount that skewed the
calibration review's slopes: a scalar doing work nobody selected it to do.

## The fix

Denominator is the **full squad's** `pred_tog`; vacated weight is priced at an
explicit replacement level — mean torp of players outside each squad's top 22 by
`pred_tog`, from the **pre-exclusion** frame so injuries cannot move it.

**Holding the denominator alone does not work**, which matters because it was the
obvious one-liner: `torp` is centred at 0, so a bare hole credits missing players
with *league-average* value. For North Melbourne that is worse than the status
quo (+10.94 vs +8.92).

## Validation — 17 snapshots, 15 rounds

`injury_list_2026.parquet` carries 20 weekly `scraped_date` vintages, so this is
not a one-round result. Over 224 team-observations where a team lost
above-replacement players:

| arm | violations of "losing above-replacement players must lower your rating" |
|---|---|
| current | **93 (41.5%)** |
| this PR | **0 (0.0%)** |

- **Identity**: 85 team-observations with nobody out, `max |delta| = 0.00e+00`.
  `18 - sum(tog_wt)` is exactly 0 there, so the non-injury-aware path is
  bit-identical and **no historical result moves**.
- **Stability**: replacement level ranges −1.41 to −1.30 across the 17 vintages —
  not fitted to one round.
- **Suite**: `FAIL 0 | ERROR 0 | SKIP 30 | PASS 2906`.

## On the tests

The aggregation is split into `.aggregate_team_torp()` so the behaviour is
testable without standing up fixtures and a full simulation. The tests call that
function, **not a copy of it** — my first version replicated the logic in the
test file and would have passed with `season_sim.R` fully reverted.

The file therefore carries a **mutation test** that runs the pre-fix aggregation
and asserts the same claims fail against it. Writing it corrected my own first
attempt: the two schemes only disagree for a player **above his replacement but
below his team's average**, and that is the case now pinned.

## Correction carried from the issue

My first framing of #151 said the defect was "10 of 18 teams rate higher with
injured players removed". That was wrong, and is corrected on the issue: losing a
below-replacement player genuinely improves a team, so some of those rises were
correct behaviour. The defect is the team-varying implicit replacement, not the
rises.

## Open, deliberately

The constant's **definition** — "outside the top 22 by predicted TOG" — is
empirical, not chosen. A different cut moves it and therefore every ladder. That
call is yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACrDta9pqRFveLKGoSGBZm
